### PR TITLE
fix: 跨平台兼容性修复 - 支持Telegram/Discord负数ID、统一PlatformHelper

### DIFF
--- a/main.py
+++ b/main.py
@@ -161,6 +161,9 @@ class MessageStatsPlugin(Star):
     async def _collect_group_unified_msg_origin(self, event: AstrMessageEvent):
         """收集群组的unified_msg_origin和群组名称
         
+        自动从 unified_msg_origin 中提取群组ID，同时以原始ID和提取的ID作为键存储，
+        确保不同平台（QQ正数ID、Telegram负数ID）都能正确匹配。
+        
         Args:
             event: 消息事件对象
         """
@@ -175,6 +178,15 @@ class MessageStatsPlugin(Star):
                 old_origin = self.group_unified_msg_origins.get(group_id_str)
                 self.group_unified_msg_origins[group_id_str] = unified_msg_origin
                 
+                # 从 unified_msg_origin 中提取群组ID（格式如 "Amydd:GroupMessage:-1003715592711"）
+                # 提取最后一个 ":" 之后的部分作为备用键
+                try:
+                    extracted_id = unified_msg_origin.rsplit(':', 1)[-1]
+                    if extracted_id and extracted_id != group_id_str:
+                        self.group_unified_msg_origins[extracted_id] = unified_msg_origin
+                except (AttributeError, IndexError, ValueError):
+                    pass
+                
                 if old_origin != unified_msg_origin:
                     self.logger.info(f"已收集群组 {group_id} 的 unified_msg_origin")
                     
@@ -187,7 +199,14 @@ class MessageStatsPlugin(Star):
                         origin_preview = unified_msg_origin[:20] + "..." if len(unified_msg_origin) > 20 else unified_msg_origin
                         self.logger.info(f"群组 {group_id} 的 unified_msg_origin: {origin_preview}")
                         
-                        if self.plugin_config.timer_enabled and group_id_str in self.plugin_config.timer_target_groups:
+                        # 检查目标群组是否匹配（支持正数/负数ID匹配）
+                        is_target_group = False
+                        for target_id in self.plugin_config.timer_target_groups:
+                            if group_id_str == target_id or extracted_id == target_id:
+                                is_target_group = True
+                                break
+                        
+                        if self.plugin_config.timer_enabled and is_target_group:
                             self.logger.info(f"检测到目标群组 {group_id} 的 unified_msg_origin 已更新，更新定时任务配置...")
                             # 确保unified_msg_origin映射表是最新的
                             self.timer_manager.push_service.group_unified_msg_origins = self.group_unified_msg_origins

--- a/main.py
+++ b/main.py
@@ -187,6 +187,10 @@ class MessageStatsPlugin(Star):
                 except (AttributeError, IndexError, ValueError):
                     pass
                 
+                # 同时以 unified_msg_origin 本身作为键存储
+                # 这样无论 timer_target_groups 中填的是群号还是 unified_msg_origin 都能匹配
+                self.group_unified_msg_origins[unified_msg_origin] = unified_msg_origin
+                
                 if old_origin != unified_msg_origin:
                     self.logger.info(f"已收集群组 {group_id} 的 unified_msg_origin")
                     

--- a/main.py
+++ b/main.py
@@ -850,10 +850,10 @@ class MessageStatsPlugin(Star):
                     # 获取群成员最新信息
                     members_info = await self._fetch_group_members_from_api(event, group_id)
                     if members_info:
-                        # 构建用户ID到最新昵称的映射
+                        # 构建用户ID到最新昵称的映射（使用 PlatformHelper 跨平台通用方式获取用户ID）
                         member_nickname_map = {}
                         for member in members_info:
-                            user_id = str(member.get("user_id", ""))
+                            user_id = PlatformHelper.get_user_id_from_member(member)
                             if user_id:
                                 # 使用群的昵称获取逻辑
                                 display_name = self._get_display_name_from_member(member)
@@ -1045,9 +1045,13 @@ class MessageStatsPlugin(Star):
         try:
             members_info = await self._fetch_group_members_from_api(event, group_id)
             if members_info:
-                # 重建字典缓存
+                # 重建字典缓存（使用 PlatformHelper 跨平台通用方式获取用户ID）
                 dict_cache_key = f"group_members_dict_{group_id}"
-                members_dict = {str(m.get("user_id", "")): m for m in members_info if m.get("user_id")}
+                members_dict = {}
+                for m in members_info:
+                    uid = PlatformHelper.get_user_id_from_member(m)
+                    if uid:
+                        members_dict[uid] = m
                 self.group_members_dict_cache[dict_cache_key] = members_dict
                 
                 # 查找用户
@@ -1331,9 +1335,13 @@ class MessageStatsPlugin(Star):
             if not members_info:
                 return
             
-            # 重建群成员字典缓存
+            # 重建群成员字典缓存（使用 PlatformHelper 跨平台通用方式获取用户ID）
             dict_cache_key = f"group_members_dict_{group_id}"
-            members_dict = {str(m.get("user_id", "")): m for m in members_info if m.get("user_id")}
+            members_dict = {}
+            for m in members_info:
+                uid = PlatformHelper.get_user_id_from_member(m)
+                if uid:
+                    members_dict[uid] = m
             self.group_members_dict_cache[dict_cache_key] = members_dict
             
             # 更新用户数据中的昵称

--- a/main.py
+++ b/main.py
@@ -202,7 +202,7 @@ class MessageStatsPlugin(Star):
         except (RuntimeError, OSError, IOError, ImportError, ValueError) as e:
             self.logger.error(f"收集群组unified_msg_origin失败(系统错误): {e}")
     async def _cache_group_name(self, event: AstrMessageEvent, group_id: str):
-        """获取并缓存群组名称
+        """获取并缓存群组名称（跨平台兼容）
         
         从事件或API获取群组名称，更新到 timer_manager 的缓存和数据文件中。
         
@@ -213,7 +213,7 @@ class MessageStatsPlugin(Star):
         try:
             group_name = None
             
-            # 方法1: 尝试通过 bot API 获取群组信息
+            # 方法1: 尝试通过 bot API 获取群组信息（QQ平台）
             if hasattr(event, 'bot') and event.bot:
                 try:
                     if hasattr(event.bot, 'api'):
@@ -226,6 +226,20 @@ class MessageStatsPlugin(Star):
                 except (AttributeError, TypeError, ValueError, asyncio.TimeoutError) as e:
                     self.logger.debug(f"通过API获取群名失败: {e}")
             
+            # 方法2: 尝试通过 context 获取（Telegram平台）
+            if not group_name and hasattr(self, 'context') and self.context:
+                try:
+                    client = self.context.bot
+                    if hasattr(client, 'api'):
+                        group_info = await client.api.call_action(
+                            'get_group_info', 
+                            group_id=int(group_id)
+                        )
+                        if group_info and isinstance(group_info, dict):
+                            group_name = group_info.get('group_name')
+                except (AttributeError, TypeError, ValueError, asyncio.TimeoutError) as e:
+                    self.logger.debug(f"通过context获取群名失败: {e}")
+            
             # 如果获取到群名，更新缓存
             if group_name:
                 self.logger.info(f"已获取群组 {group_id} 的名称: {group_name}")
@@ -233,10 +247,6 @@ class MessageStatsPlugin(Star):
                 # 更新到 timer_manager 的内存缓存
                 if self.timer_manager:
                     self.timer_manager.update_group_name_cache(group_id, group_name)
-                
-                # 更新到数据文件（下次保存时会自动包含）
-                # 这里我们可以单独保存群名，但为了简化，我们只更新内存缓存
-                # 群名会在下次保存群组数据时一并保存
                 
         except (AttributeError, KeyError, TypeError, RuntimeError) as e:
             self.logger.debug(f"缓存群组名称失败: {e}")
@@ -462,7 +472,7 @@ class MessageStatsPlugin(Star):
         """自动消息监听器 - 监听所有消息并记录群成员发言统计"""
         # 跳过命令消息
         message_str = getattr(event, 'message_str', '')
-        if message_str.startswith(('%', '/')):
+        if not message_str or message_str.startswith(('%', '/')):
             return
         
         # 获取基本信息
@@ -1184,12 +1194,30 @@ class MessageStatsPlugin(Star):
             return await self._fetch_group_members_from_api(event, group_id)
     
     async def _fetch_group_members_from_api(self, event: AstrMessageEvent, group_id: str) -> Optional[List[Dict[str, Any]]]:
-        """从API获取群成员"""
-        client = event.bot
+        """从API获取群成员（跨平台兼容）"""
+        # 尝试获取 API 客户端，兼容不同平台（QQ 平台使用 event.bot，Telegram 平台使用 self.context）
+        client = None
+        if hasattr(event, 'bot') and event.bot:
+            client = event.bot
+        elif hasattr(self, 'context') and self.context:
+            try:
+                client = self.context.bot
+            except (AttributeError, KeyError, TypeError):
+                pass
+        
+        if not client:
+            self.logger.debug(f"无法获取API客户端，跳过群成员列表获取（群 {group_id}）")
+            return None
+        
         params = {"group_id": group_id}
         
         try:
-            members_info = await client.api.call_action('get_group_member_list', **params)
+            if hasattr(client, 'api'):
+                members_info = await client.api.call_action('get_group_member_list', **params)
+            else:
+                self.logger.debug(f"API客户端没有api属性，跳过群成员列表获取（群 {group_id}）")
+                return None
+            
             if members_info:
                 # 缓存群成员列表,设置合理的过期时间
                 cache_key = f"group_members_{group_id}"
@@ -1226,16 +1254,26 @@ class MessageStatsPlugin(Star):
                        getattr(group_data, 'group_title', None) or \
                        f"群{group_id}"
             
-            # 如果事件对象获取失败，尝试通过API获取
+            # 如果事件对象获取失败，尝试通过API获取（跨平台兼容）
             try:
+                # 尝试从 event.bot 获取（QQ平台）
+                client = None
                 if hasattr(event, 'bot') and hasattr(event.bot, 'api'):
-                    group_info = await event.bot.api.call_action('get_group_info', group_id=group_id)
+                    client = event.bot
+                # 尝试从 self.context 获取（Telegram平台）
+                elif hasattr(self, 'context') and self.context:
+                    try:
+                        client = self.context.bot
+                    except (AttributeError, KeyError, TypeError):
+                        pass
+                
+                if client and hasattr(client, 'api'):
+                    group_info = await client.api.call_action('get_group_info', group_id=group_id)
                     if group_info and isinstance(group_info, dict):
                         group_name = group_info.get('group_name') or group_info.get('group_title') or group_info.get('name')
                         if group_name:
                             return str(group_name).strip()
             except (ConnectionError, asyncio.TimeoutError, ValueError, TypeError, AttributeError) as api_error:
-                # 修复：替换过于宽泛的Exception为具体异常类型
                 self.logger.warning(f"通过API获取群组 {group_id} 名称失败: {api_error}")
             
             return f"群{group_id}"

--- a/main.py
+++ b/main.py
@@ -203,10 +203,13 @@ class MessageStatsPlugin(Star):
                         origin_preview = unified_msg_origin[:20] + "..." if len(unified_msg_origin) > 20 else unified_msg_origin
                         self.logger.info(f"群组 {group_id} 的 unified_msg_origin: {origin_preview}")
                         
-                        # 检查目标群组是否匹配（支持正数/负数ID匹配）
+                        # 检查目标群组是否匹配（支持多种格式）
+                        # timer_target_groups 可能存储的是：
+                        #   1. 群组ID（如 -1003715592711 或 1081839722）
+                        #   2. unified_msg_origin 字符串（如 Amy:GroupMessage:1081839722）
                         is_target_group = False
                         for target_id in self.plugin_config.timer_target_groups:
-                            if group_id_str == target_id or extracted_id == target_id:
+                            if group_id_str == target_id or extracted_id == target_id or unified_msg_origin == target_id:
                                 is_target_group = True
                                 break
                         

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from astrbot.api import logger as astrbot_logger
 from .utils.data_manager import DataManager
 from .utils.image_generator import ImageGenerator, ImageGenerationError
 from .utils.validators import Validators
+from .utils.platform_helper import PlatformHelper
 
 from .utils.models import (
     UserData, PluginConfig, GroupInfo, MessageDate, 
@@ -202,43 +203,18 @@ class MessageStatsPlugin(Star):
         except (RuntimeError, OSError, IOError, ImportError, ValueError) as e:
             self.logger.error(f"收集群组unified_msg_origin失败(系统错误): {e}")
     async def _cache_group_name(self, event: AstrMessageEvent, group_id: str):
-        """获取并缓存群组名称（跨平台兼容）
+        """获取并缓存群组名称（跨平台通用）
         
-        从事件或API获取群组名称，更新到 timer_manager 的缓存和数据文件中。
+        使用 PlatformHelper 统一获取群组名称，支持所有平台。
         
         Args:
             event: 消息事件对象
             group_id: 群组ID
         """
         try:
-            group_name = None
-            
-            # 方法1: 尝试通过 bot API 获取群组信息（QQ平台）
-            if hasattr(event, 'bot') and event.bot:
-                try:
-                    if hasattr(event.bot, 'api'):
-                        group_info = await event.bot.api.call_action(
-                            'get_group_info', 
-                            group_id=int(group_id)
-                        )
-                        if group_info and isinstance(group_info, dict):
-                            group_name = group_info.get('group_name')
-                except (AttributeError, TypeError, ValueError, asyncio.TimeoutError) as e:
-                    self.logger.debug(f"通过API获取群名失败: {e}")
-            
-            # 方法2: 尝试通过 context 获取（Telegram平台）
-            if not group_name and hasattr(self, 'context') and self.context:
-                try:
-                    client = self.context.bot
-                    if hasattr(client, 'api'):
-                        group_info = await client.api.call_action(
-                            'get_group_info', 
-                            group_id=int(group_id)
-                        )
-                        if group_info and isinstance(group_info, dict):
-                            group_name = group_info.get('group_name')
-                except (AttributeError, TypeError, ValueError, asyncio.TimeoutError) as e:
-                    self.logger.debug(f"通过context获取群名失败: {e}")
+            # 使用 PlatformHelper 统一获取群组名称（跨平台通用）
+            helper = PlatformHelper(event, self.context)
+            group_name = await helper.get_group_name(group_id)
             
             # 如果获取到群名，更新缓存
             if group_name:
@@ -987,9 +963,9 @@ class MessageStatsPlugin(Star):
     
     @data_operation_handler('extract', '群成员昵称数据')
     def _get_display_name_from_member(self, member: Dict[str, Any]) -> Optional[str]:
-        """从群成员信息中提取显示昵称
+        """从群成员信息中提取显示昵称（跨平台通用）
         
-        提取用户昵称的辅助函数，避免重复的逻辑
+        使用 PlatformHelper 统一提取昵称，支持所有平台。
         
         Args:
             member (Dict[str, Any]): 群成员信息字典
@@ -997,7 +973,7 @@ class MessageStatsPlugin(Star):
         Returns:
             Optional[str]: 用户的显示昵称，如果获取失败则返回None
         """
-        return member.get("card") or member.get("nickname")
+        return PlatformHelper.get_display_name_from_member(member)
 
     async def _get_user_nickname_unified(self, event: AstrMessageEvent, group_id: str, user_id: str) -> str:
         """统一的用户昵称获取方法 - 性能优先版本（缓存优先策略）
@@ -1194,55 +1170,46 @@ class MessageStatsPlugin(Star):
             return await self._fetch_group_members_from_api(event, group_id)
     
     async def _fetch_group_members_from_api(self, event: AstrMessageEvent, group_id: str) -> Optional[List[Dict[str, Any]]]:
-        """从API获取群成员（跨平台兼容）"""
-        # 尝试获取 API 客户端，兼容不同平台（QQ 平台使用 event.bot，Telegram 平台使用 self.context）
-        client = None
-        if hasattr(event, 'bot') and event.bot:
-            client = event.bot
-        elif hasattr(self, 'context') and self.context:
-            try:
-                client = self.context.bot
-            except (AttributeError, KeyError, TypeError):
-                pass
+        """从API获取群成员（跨平台通用）
         
-        if not client:
-            self.logger.debug(f"无法获取API客户端，跳过群成员列表获取（群 {group_id}）")
-            return None
+        使用 PlatformHelper 统一获取群成员列表，支持所有平台。
         
-        params = {"group_id": group_id}
-        
-        try:
-            if hasattr(client, 'api'):
-                members_info = await client.api.call_action('get_group_member_list', **params)
-            else:
-                self.logger.debug(f"API客户端没有api属性，跳过群成员列表获取（群 {group_id}）")
-                return None
+        Args:
+            event: 消息事件对象
+            group_id: 群组ID
             
-            if members_info:
-                # 缓存群成员列表,设置合理的过期时间
-                cache_key = f"group_members_{group_id}"
-                self.group_members_cache[cache_key] = members_info
-                
-                # 对于大群(成员数>500),记录警告
-                if len(members_info) > 500:
-                    self.logger.warning(f"群 {group_id} 成员数较多({len(members_info)}),建议调整缓存策略")
-                
-                return members_info
-        except (AttributeError, KeyError, TypeError) as e:
-            self.logger.warning(f"获取群成员列表失败(数据格式错误): {e}")
-        except (ConnectionError, TimeoutError, OSError) as e:
-            self.logger.warning(f"获取群成员列表失败(网络错误): {e}")
-        except ImportError as e:
-            self.logger.warning(f"获取群成员列表失败(导入错误): {e}")
-        except RuntimeError as e:
-            self.logger.warning(f"获取群成员列表失败(运行时错误): {e}")
-        except ValueError as e:
-            self.logger.warning(f"获取群成员列表失败(数据格式错误): {e}")
+        Returns:
+            群成员列表，如果获取失败则返回 None
+        """
+        # 使用 PlatformHelper 统一获取群成员列表（跨平台通用）
+        helper = PlatformHelper(event, self.context)
+        members_info = await helper.get_group_members(group_id)
+        
+        if members_info:
+            # 缓存群成员列表,设置合理的过期时间
+            cache_key = f"group_members_{group_id}"
+            self.group_members_cache[cache_key] = members_info
+            
+            # 对于大群(成员数>500),记录警告
+            if len(members_info) > 500:
+                self.logger.warning(f"群 {group_id} 成员数较多({len(members_info)}),建议调整缓存策略")
+            
+            return members_info
         
         return None
 
     async def _get_group_name(self, event: AstrMessageEvent, group_id: str) -> str:
-        """获取群名称 - 改进版本"""
+        """获取群名称（跨平台通用）
+        
+        使用 PlatformHelper 统一获取群组名称，支持所有平台。
+        
+        Args:
+            event: 消息事件对象
+            group_id: 群组ID
+            
+        Returns:
+            群组名称，如果获取失败则返回 "群{group_id}"
+        """
         try:
             # 首先尝试通过事件对象获取群组信息
             group_data = await event.get_group(group_id)
@@ -1254,27 +1221,11 @@ class MessageStatsPlugin(Star):
                        getattr(group_data, 'group_title', None) or \
                        f"群{group_id}"
             
-            # 如果事件对象获取失败，尝试通过API获取（跨平台兼容）
-            try:
-                # 尝试从 event.bot 获取（QQ平台）
-                client = None
-                if hasattr(event, 'bot') and hasattr(event.bot, 'api'):
-                    client = event.bot
-                # 尝试从 self.context 获取（Telegram平台）
-                elif hasattr(self, 'context') and self.context:
-                    try:
-                        client = self.context.bot
-                    except (AttributeError, KeyError, TypeError):
-                        pass
-                
-                if client and hasattr(client, 'api'):
-                    group_info = await client.api.call_action('get_group_info', group_id=group_id)
-                    if group_info and isinstance(group_info, dict):
-                        group_name = group_info.get('group_name') or group_info.get('group_title') or group_info.get('name')
-                        if group_name:
-                            return str(group_name).strip()
-            except (ConnectionError, asyncio.TimeoutError, ValueError, TypeError, AttributeError) as api_error:
-                self.logger.warning(f"通过API获取群组 {group_id} 名称失败: {api_error}")
+            # 如果事件对象获取失败，使用 PlatformHelper 统一通过API获取（跨平台通用）
+            helper = PlatformHelper(event, self.context)
+            group_name = await helper.get_group_name(group_id)
+            if group_name:
+                return str(group_name).strip()
             
             return f"群{group_id}"
         except (AttributeError, KeyError, TypeError, OSError) as e:

--- a/utils/data_manager.py
+++ b/utils/data_manager.py
@@ -151,6 +151,25 @@ class DataManager:
         await self.save_config(default_config)
         self.logger.info("已创建默认配置文件")
     
+    @staticmethod
+    def _is_valid_group_id(group_id: str) -> bool:
+        """验证群组ID是否为有效的数字格式（支持负数，如Telegram的群组ID）
+        
+        Args:
+            group_id (str): 群组ID字符串
+            
+        Returns:
+            bool: 是否为有效的数字格式
+        """
+        if not group_id:
+            return False
+        group_id_str = str(group_id).strip()
+        # 处理前导负号（Telegram 群组ID为负数）
+        if group_id_str.startswith('-'):
+            numeric_part = group_id_str[1:]
+            return numeric_part.isdigit() and len(numeric_part) >= 1
+        return group_id_str.isdigit() and len(group_id_str) >= 1
+
     def _validate_json_content(self, content: str) -> bool:
         """验证JSON内容格式
         
@@ -253,7 +272,7 @@ class DataManager:
         从缓存或文件读取指定群组的用户数据。
         
         Args:
-            group_id (str): 群组ID，必须是有效的数字字符串
+            group_id (str): 群组ID，必须是有效的数字字符串（支持负数，如Telegram群组ID）
             
         Returns:
             List[UserData]: 用户数据列表，如果读取失败则返回空列表
@@ -261,7 +280,7 @@ class DataManager:
         Raises:
             ValueError: 当group_id格式不正确时
         """
-        if not group_id.isdigit():
+        if not self._is_valid_group_id(group_id):
             raise ValueError(f"群组ID必须是数字字符串，当前值: {group_id}")
         
         cache_key = f"group_data_{group_id}"
@@ -284,7 +303,7 @@ class DataManager:
         异步保存指定群组的用户数据到JSON文件，并清除相关缓存。
         
         Args:
-            group_id (str): 群组ID，必须是有效的数字字符串
+            group_id (str): 群组ID，必须是有效的数字字符串（支持负数，如Telegram群组ID）
             users (List[UserData]): 用户数据列表，将被序列化为JSON格式保存
             
         Returns:
@@ -293,7 +312,7 @@ class DataManager:
         Raises:
             ValueError: 当group_id格式不正确时
         """
-        if not group_id.isdigit():
+        if not self._is_valid_group_id(group_id):
             raise ValueError(f"群组ID必须是数字字符串，当前值: {group_id}")
         
         # 使用GroupDataStore保存数据
@@ -319,8 +338,8 @@ class DataManager:
         使用基于群组ID的锁机制防止并发安全问题。
         
         Args:
-            group_id (str): 群组ID
-            user_id (str): 用户ID
+            group_id (str): 群组ID（支持负数，如Telegram群组ID）
+            user_id (str): 用户ID（支持负数，如Telegram用户ID）
             nickname (str): 用户昵称
             
         Returns:
@@ -329,10 +348,16 @@ class DataManager:
         Raises:
             ValueError: 当参数格式不正确时
         """
-        if not group_id.isdigit():
+        if not self._is_valid_group_id(group_id):
             raise ValueError(f"群组ID必须是数字字符串，当前值: {group_id}")
         
-        if not user_id.isdigit():
+        # 验证用户ID（支持负数，如Telegram用户ID）
+        user_id_str = str(user_id).strip()
+        if user_id_str.startswith('-'):
+            numeric_part = user_id_str[1:]
+            if not numeric_part.isdigit():
+                raise ValueError(f"用户ID必须是数字字符串，当前值: {user_id}")
+        elif not user_id_str.isdigit():
             raise ValueError(f"用户ID必须是数字字符串，当前值: {user_id}")
         
         # 获取群组级别的锁，确保同一群组的数据操作串行化

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -359,8 +359,8 @@ class ImageGenerator:
             # 生成HTML内容
             html_content = await self._generate_html(users, group_info, title, current_user_id)
             
-            # 设置页面内容
-            await self.page.set_content(html_content, wait_until="networkidle")
+            # 设置页面内容（使用 load 而非 networkidle，避免外部资源加载超时）
+            await self.page.set_content(html_content, wait_until="load")
             
             # 等待页面加载完成
             await self.page.wait_for_timeout(2000)

--- a/utils/platform_helper.py
+++ b/utils/platform_helper.py
@@ -1,0 +1,450 @@
+"""
+平台兼容性辅助模块
+
+提供统一的跨平台兼容接口，支持 QQ、Telegram、Discord、飞书 等不同平台。
+所有平台相关的操作都集中在此模块中，避免在业务代码中分散处理。
+
+支持的平台：
+- QQ (OneBot 协议)
+- Telegram
+- Discord
+- 飞书 (Lark/Feishu)
+- 以及其他 AstrBot 支持的平台
+
+使用方式：
+    helper = PlatformHelper(event, context)
+    client = await helper.get_api_client()
+    members = await helper.get_group_members(group_id)
+    group_name = await helper.get_group_name(group_id)
+"""
+
+import asyncio
+from typing import List, Optional, Dict, Any, Union
+from astrbot.api import logger as astrbot_logger
+from astrbot.api.event import AstrMessageEvent
+from astrbot.api.star import Context
+
+
+class PlatformHelper:
+    """平台兼容性辅助类
+    
+    统一封装所有平台相关的操作，提供跨平台兼容的接口。
+    所有方法都使用 hasattr + try/except 双重保护，确保在任何平台上都不会崩溃。
+    
+    Attributes:
+        event: AstrMessageEvent 消息事件对象
+        context: AstrBot Context 上下文对象
+        logger: 日志记录器
+    """
+    
+    def __init__(self, event: AstrMessageEvent = None, context: Context = None):
+        """初始化 PlatformHelper
+        
+        Args:
+            event: AstrMessageEvent 消息事件对象（可选）
+            context: AstrBot Context 上下文对象（可选）
+        """
+        self.event = event
+        self.context = context
+        self.logger = astrbot_logger
+    
+    def set_event(self, event: AstrMessageEvent):
+        """设置消息事件对象"""
+        self.event = event
+    
+    def set_context(self, context: Context):
+        """设置上下文对象"""
+        self.context = context
+    
+    # ========== API 客户端获取 ==========
+    
+    async def get_api_client(self) -> Optional[Any]:
+        """获取 API 客户端（跨平台通用）
+        
+        尝试从多个来源获取 API 客户端：
+        1. event.bot（QQ 平台）
+        2. context.bot（Telegram、Discord、飞书等平台）
+        3. context.get_bot()（某些平台的备用方式）
+        
+        Returns:
+            API 客户端对象，如果所有方式都失败则返回 None
+        """
+        client = None
+        
+        # 方式1: 从 event.bot 获取（QQ 平台）
+        if self.event and hasattr(self.event, 'bot') and self.event.bot:
+            client = self.event.bot
+        
+        # 方式2: 从 context.bot 获取（Telegram、Discord、飞书等平台）
+        if not client and self.context and hasattr(self.context, 'bot'):
+            try:
+                client = self.context.bot
+            except (AttributeError, KeyError, TypeError):
+                pass
+        
+        # 方式3: 从 context.get_bot() 获取（某些平台的备用方式）
+        if not client and self.context and hasattr(self.context, 'get_bot'):
+            try:
+                client = await self.context.get_bot()
+            except (AttributeError, KeyError, TypeError, NotImplementedError):
+                pass
+        
+        return client
+    
+    async def call_api(self, action: str, **params) -> Optional[Any]:
+        """调用平台 API（跨平台通用）
+        
+        统一的 API 调用接口，自动处理不同平台的差异。
+        
+        Args:
+            action: API 动作名称（如 'get_group_member_list', 'get_group_info'）
+            **params: API 参数
+            
+        Returns:
+            API 响应结果，如果调用失败则返回 None
+        """
+        client = await self.get_api_client()
+        if not client:
+            self.logger.debug(f"无法获取API客户端，跳过API调用: {action}")
+            return None
+        
+        try:
+            if hasattr(client, 'api'):
+                return await client.api.call_action(action, **params)
+            else:
+                self.logger.debug(f"API客户端没有api属性，跳过API调用: {action}")
+                return None
+        except (AttributeError, KeyError, TypeError) as e:
+            self.logger.debug(f"API调用失败({action}): {e}")
+        except (ConnectionError, TimeoutError, OSError) as e:
+            self.logger.debug(f"API调用网络错误({action}): {e}")
+        except (ImportError, RuntimeError, ValueError) as e:
+            self.logger.debug(f"API调用错误({action}): {e}")
+        
+        return None
+    
+    # ========== ID 验证 ==========
+    
+    @staticmethod
+    def is_valid_numeric_id(id_value: Any) -> bool:
+        """验证是否为有效的数字ID（跨平台通用）
+        
+        支持：
+        - 正数ID（QQ 平台）：123456789
+        - 负数ID（Telegram 平台）：-1001234567890
+        - 字符串数字ID：'123456789'
+        - Discord 的数值ID：123456789012345678
+        
+        Args:
+            id_value: 要验证的ID值
+            
+        Returns:
+            bool: 是否为有效的数字ID
+        """
+        if id_value is None:
+            return False
+        
+        id_str = str(id_value).strip()
+        if not id_str:
+            return False
+        
+        # 处理前导负号（Telegram 平台）
+        if id_str.startswith('-'):
+            numeric_part = id_str[1:]
+            return bool(numeric_part) and numeric_part.isdigit()
+        
+        # 正数ID
+        return id_str.isdigit()
+    
+    @staticmethod
+    def normalize_id(id_value: Any) -> str:
+        """标准化ID为字符串（跨平台通用）
+        
+        将各种格式的ID统一转换为字符串，去除空白字符。
+        
+        Args:
+            id_value: 要标准化的ID值
+            
+        Returns:
+            str: 标准化后的ID字符串
+        """
+        if id_value is None:
+            return ""
+        return str(id_value).strip()
+    
+    # ========== 群组操作 ==========
+    
+    async def get_group_members(self, group_id: str) -> Optional[List[Dict[str, Any]]]:
+        """获取群成员列表（跨平台通用）
+        
+        统一的群成员获取接口，自动适配不同平台的 API。
+        
+        Args:
+            group_id: 群组ID
+            
+        Returns:
+            群成员列表，如果获取失败则返回 None
+        """
+        return await self.call_api('get_group_member_list', group_id=group_id)
+    
+    async def get_group_info(self, group_id: str) -> Optional[Dict[str, Any]]:
+        """获取群组信息（跨平台通用）
+        
+        统一的群组信息获取接口，自动适配不同平台的 API。
+        
+        Args:
+            group_id: 群组ID
+            
+        Returns:
+            群组信息字典，如果获取失败则返回 None
+        """
+        return await self.call_api('get_group_info', group_id=group_id)
+    
+    async def get_group_name(self, group_id: str) -> Optional[str]:
+        """获取群组名称（跨平台通用）
+        
+        统一的群组名称获取接口，自动适配不同平台的 API 返回格式。
+        
+        Args:
+            group_id: 群组ID
+            
+        Returns:
+            群组名称，如果获取失败则返回 None
+        """
+        group_info = await self.get_group_info(group_id)
+        if group_info and isinstance(group_info, dict):
+            # 尝试多种可能的字段名（不同平台返回格式不同）
+            return (group_info.get('group_name') or 
+                    group_info.get('group_title') or 
+                    group_info.get('name') or 
+                    group_info.get('title') or
+                    group_info.get('chat_name') or
+                    group_info.get('nickname'))
+        return None
+    
+    # ========== 用户信息获取 ==========
+    
+    async def get_user_info(self, group_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+        """获取群成员信息（跨平台通用）
+        
+        Args:
+            group_id: 群组ID
+            user_id: 用户ID
+            
+        Returns:
+            用户信息字典，如果获取失败则返回 None
+        """
+        return await self.call_api('get_group_member_info', group_id=group_id, user_id=user_id)
+    
+    @staticmethod
+    def get_display_name_from_member(member: Dict[str, Any]) -> Optional[str]:
+        """从群成员信息中提取显示昵称（跨平台通用）
+        
+        支持不同平台的昵称字段名：
+        - QQ: card（群昵称）> nickname（QQ昵称）
+        - Telegram: first_name + last_name > username
+        - Discord: nickname（群昵称）> global_name > username
+        - 飞书: name
+        
+        Args:
+            member: 群成员信息字典
+            
+        Returns:
+            用户的显示昵称，如果获取失败则返回 None
+        """
+        if not member or not isinstance(member, dict):
+            return None
+        
+        # QQ 平台：card（群昵称）> nickname（QQ昵称）
+        display_name = member.get('card') or member.get('nickname')
+        if display_name:
+            return str(display_name).strip()
+        
+        # Telegram 平台：first_name + last_name
+        first_name = member.get('first_name', '')
+        last_name = member.get('last_name', '')
+        if first_name or last_name:
+            return f"{first_name} {last_name}".strip()
+        
+        # Telegram 备用：username
+        username = member.get('username')
+        if username:
+            return f"@{username}"
+        
+        # Discord 平台：nickname（群昵称）> global_name > username
+        display_name = member.get('nick') or member.get('global_name') or member.get('username')
+        if display_name:
+            return str(display_name).strip()
+        
+        # 飞书平台：name
+        name = member.get('name')
+        if name:
+            return str(name).strip()
+        
+        return None
+    
+    @staticmethod
+    def get_user_id_from_member(member: Dict[str, Any]) -> Optional[str]:
+        """从群成员信息中提取用户ID（跨平台通用）
+        
+        支持不同平台的用户ID字段名：
+        - QQ: user_id
+        - Telegram: id
+        - Discord: id
+        - 飞书: user_id / open_id
+        
+        Args:
+            member: 群成员信息字典
+            
+        Returns:
+            用户ID字符串，如果获取失败则返回 None
+        """
+        if not member or not isinstance(member, dict):
+            return None
+        
+        # QQ 平台
+        user_id = member.get('user_id')
+        if user_id is not None:
+            return str(user_id)
+        
+        # Telegram / Discord / 飞书 平台
+        user_id = member.get('id')
+        if user_id is not None:
+            return str(user_id)
+        
+        # 飞书备用
+        user_id = member.get('open_id') or member.get('union_id')
+        if user_id is not None:
+            return str(user_id)
+        
+        return None
+    
+    # ========== 事件信息获取 ==========
+    
+    def get_group_id_from_event(self) -> Optional[str]:
+        """从事件中获取群组ID（跨平台通用）
+        
+        Returns:
+            群组ID字符串，如果无法获取则返回 None
+        """
+        if not self.event:
+            return None
+        
+        try:
+            group_id = self.event.get_group_id()
+            return str(group_id) if group_id else None
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    def get_user_id_from_event(self) -> Optional[str]:
+        """从事件中获取用户ID（跨平台通用）
+        
+        Returns:
+            用户ID字符串，如果无法获取则返回 None
+        """
+        if not self.event:
+            return None
+        
+        try:
+            user_id = self.event.get_sender_id()
+            return str(user_id) if user_id else None
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    def get_self_id_from_event(self) -> Optional[str]:
+        """从事件中获取机器人自身ID（跨平台通用）
+        
+        Returns:
+            机器人自身ID字符串，如果无法获取则返回 None
+        """
+        if not self.event:
+            return None
+        
+        try:
+            self_id = self.event.get_self_id()
+            return str(self_id) if self_id else None
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    def get_sender_name_from_event(self) -> Optional[str]:
+        """从事件中获取发送者名称（跨平台通用）
+        
+        Returns:
+            发送者名称，如果无法获取则返回 None
+        """
+        if not self.event:
+            return None
+        
+        try:
+            return self.event.get_sender_name()
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    def get_message_str_from_event(self) -> str:
+        """从事件中获取消息文本（跨平台通用）
+        
+        Returns:
+            消息文本字符串，如果无法获取则返回空字符串
+        """
+        if not self.event:
+            return ""
+        
+        try:
+            return getattr(self.event, 'message_str', '') or ''
+        except (AttributeError, KeyError, TypeError):
+            return ""
+    
+    def get_unified_msg_origin_from_event(self) -> Optional[str]:
+        """从事件中获取 unified_msg_origin（跨平台通用）
+        
+        Returns:
+            unified_msg_origin 字符串，如果无法获取则返回 None
+        """
+        if not self.event:
+            return None
+        
+        try:
+            return getattr(self.event, 'unified_msg_origin', None)
+        except (AttributeError, KeyError, TypeError):
+            return None
+    
+    # ========== 群成员列表处理 ==========
+    
+    @staticmethod
+    def build_members_dict(members_info: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        """构建群成员字典（以用户ID为键）
+        
+        将群成员列表转换为以用户ID为键的字典，方便快速查找。
+        自动适配不同平台的用户ID字段名。
+        
+        Args:
+            members_info: 群成员信息列表
+            
+        Returns:
+            以用户ID为键的群成员字典
+        """
+        members_dict = {}
+        for member in members_info:
+            user_id = PlatformHelper.get_user_id_from_member(member)
+            if user_id:
+                members_dict[user_id] = member
+        return members_dict
+    
+    @staticmethod
+    def find_member_in_list(members_info: List[Dict[str, Any]], user_id: str) -> Optional[Dict[str, Any]]:
+        """在群成员列表中查找指定用户
+        
+        自动适配不同平台的用户ID字段名。
+        
+        Args:
+            members_info: 群成员信息列表
+            user_id: 要查找的用户ID
+            
+        Returns:
+            用户信息字典，如果未找到则返回 None
+        """
+        for member in members_info:
+            mid = PlatformHelper.get_user_id_from_member(member)
+            if mid == user_id:
+                return member
+        return None

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -231,14 +231,19 @@ class TimerManager:
                 self.logger.error("定时配置验证失败")
                 return False
             
-            # 检查unified_msg_origin可用性（支持正数/负数ID匹配）
+            # 检查unified_msg_origin可用性（支持多种匹配方式）
+            # timer_target_groups 可能存储的是：
+            #   1. 群组ID（如 -1003715592711 或 1081839722）
+            #   2. unified_msg_origin 字符串（如 Amy:GroupMessage:1081839722）
             missing_origins = []
             for group_id in config.timer_target_groups:
                 group_id_str = str(group_id)
-                # 直接匹配
+                
+                # 方式1: 直接匹配键名
                 if group_id_str in self.push_service.group_unified_msg_origins:
                     continue
-                # 尝试从 unified_msg_origin 的值中匹配（提取最后一个:后的部分）
+                
+                # 方式2: 匹配 unified_msg_origin 的值（提取最后一个:后的部分）
                 found = False
                 for origin_key, origin_value in self.push_service.group_unified_msg_origins.items():
                     try:
@@ -248,6 +253,27 @@ class TimerManager:
                             break
                     except (AttributeError, IndexError, ValueError):
                         continue
+                
+                # 方式3: 如果 group_id_str 本身是 unified_msg_origin 格式（如 Amy:GroupMessage:1081839722）
+                # 尝试提取其中的群组ID并匹配
+                if not found and ':' in group_id_str:
+                    try:
+                        extracted_from_target = group_id_str.rsplit(':', 1)[-1]
+                        if extracted_from_target in self.push_service.group_unified_msg_origins:
+                            found = True
+                        # 方式4: 用提取的ID去匹配 unified_msg_origin 的值
+                        if not found:
+                            for origin_key, origin_value in self.push_service.group_unified_msg_origins.items():
+                                try:
+                                    origin_extracted = origin_value.rsplit(':', 1)[-1]
+                                    if origin_extracted == extracted_from_target:
+                                        found = True
+                                        break
+                                except (AttributeError, IndexError, ValueError):
+                                    continue
+                    except (AttributeError, IndexError, ValueError):
+                        pass
+                
                 if not found:
                     missing_origins.append(group_id_str)
             
@@ -432,20 +458,32 @@ class TimerManager:
                 self.logger.warning(f"跳过无效的群组ID类型: {type(group_id)}")
                 continue
             
-            # 支持正数ID（QQ）和负数ID（Telegram）
             group_id_str = str(group_id).strip()
             if not group_id_str:
                 self.logger.warning(f"跳过空的群组ID")
                 continue
+            
+            # timer_target_groups 可能存储的是：
+            #   1. 群组ID（如 -1003715592711 或 1081839722）
+            #   2. unified_msg_origin 字符串（如 Amy:GroupMessage:1081839722）
+            # 如果是 unified_msg_origin 格式，尝试提取其中的群组ID
+            actual_group_id = group_id_str
+            if ':' in group_id_str:
+                try:
+                    extracted = group_id_str.rsplit(':', 1)[-1]
+                    if extracted.lstrip('-').isdigit():
+                        actual_group_id = extracted
+                        self.logger.debug(f"从 unified_msg_origin 中提取群组ID: {group_id_str} -> {actual_group_id}")
+                except (AttributeError, IndexError, ValueError):
+                    pass
+            
             # 验证是否为有效的数字ID（支持负数）
-            if group_id_str.lstrip('-').isdigit():
-                pass  # 有效ID
-            else:
+            if not actual_group_id.lstrip('-').isdigit():
                 self.logger.warning(f"跳过无效的群组ID格式: {group_id}")
                 continue
             
             # 推送到指定群组
-            success = await self._push_to_group(group_id_str, config)
+            success = await self._push_to_group(actual_group_id, config)
             if success:
                 success_count += 1
                 self.logger.info(f"✅ 群组 {group_id} 推送成功")

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -278,7 +278,7 @@ class TimerManager:
                     missing_origins.append(group_id_str)
             
             if missing_origins:
-                self.logger.warning(f"⚠️ 以下群组缺少unified_msg_origin: {', '.join(missing_origins)}")
+                self.logger.info(f"📋 以下群组尚未收集unified_msg_origin: {', '.join(missing_origins)}")
                 self.logger.info("💡 解决方案: 在对应群组中发送任意消息以收集unified_msg_origin")
                 self.logger.info("📝 定时任务仍会启动，但推送时会失败直到unified_msg_origin被收集")
                 self.logger.info("📋 提示: 可以使用 #手动推送发言榜 命令测试推送功能")

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -231,11 +231,25 @@ class TimerManager:
                 self.logger.error("定时配置验证失败")
                 return False
             
-            # 检查unified_msg_origin可用性
+            # 检查unified_msg_origin可用性（支持正数/负数ID匹配）
             missing_origins = []
             for group_id in config.timer_target_groups:
-                if str(group_id) not in self.push_service.group_unified_msg_origins:
-                    missing_origins.append(str(group_id))
+                group_id_str = str(group_id)
+                # 直接匹配
+                if group_id_str in self.push_service.group_unified_msg_origins:
+                    continue
+                # 尝试从 unified_msg_origin 的值中匹配（提取最后一个:后的部分）
+                found = False
+                for origin_key, origin_value in self.push_service.group_unified_msg_origins.items():
+                    try:
+                        extracted_id = origin_value.rsplit(':', 1)[-1]
+                        if extracted_id == group_id_str:
+                            found = True
+                            break
+                    except (AttributeError, IndexError, ValueError):
+                        continue
+                if not found:
+                    missing_origins.append(group_id_str)
             
             if missing_origins:
                 self.logger.warning(f"⚠️ 以下群组缺少unified_msg_origin: {', '.join(missing_origins)}")

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -432,12 +432,20 @@ class TimerManager:
                 self.logger.warning(f"跳过无效的群组ID类型: {type(group_id)}")
                 continue
             
-            if not group_id.isdigit():
+            # 支持正数ID（QQ）和负数ID（Telegram）
+            group_id_str = str(group_id).strip()
+            if not group_id_str:
+                self.logger.warning(f"跳过空的群组ID")
+                continue
+            # 验证是否为有效的数字ID（支持负数）
+            if group_id_str.lstrip('-').isdigit():
+                pass  # 有效ID
+            else:
                 self.logger.warning(f"跳过无效的群组ID格式: {group_id}")
                 continue
             
             # 推送到指定群组
-            success = await self._push_to_group(group_id, config)
+            success = await self._push_to_group(group_id_str, config)
             if success:
                 success_count += 1
                 self.logger.info(f"✅ 群组 {group_id} 推送成功")

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -112,9 +112,9 @@ class Validators:
             if not numeric_part.isdigit():
                 raise ValidationError("群组ID必须是数字")
         
-        # 对数字部分做长度检查，上限放宽至15以兼容Telegram超级群长ID
-        if len(numeric_part) < GROUP_ID_MIN_LENGTH or len(numeric_part) > 15:
-            raise ValidationError(f"群组ID数字部分长度应在{GROUP_ID_MIN_LENGTH}-15位之间")
+        # 对数字部分做长度检查，上限放宽至20以兼容Discord长ID（19位）
+        if len(numeric_part) < GROUP_ID_MIN_LENGTH or len(numeric_part) > 20:
+            raise ValidationError(f"群组ID数字部分长度应在{GROUP_ID_MIN_LENGTH}-20位之间")
         
         return group_id_str
     

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -122,7 +122,8 @@ class Validators:
     def validate_user_id(user_id: Any) -> str:
         """验证用户ID格式
         
-        验证用户ID是否符合规范，必须是1-20位数字。
+        验证用户ID是否符合规范，支持正数ID（QQ等平台）和负号ID（Telegram等平台）。
+        数字部分长度需在1-20位之间。
         
         Args:
             user_id (Any): 要验证的用户ID，可以是任何类型
@@ -138,20 +139,28 @@ class Validators:
             '987654321'
             >>> Validators.validate_user_id(987654321)
             '987654321'
+            >>> Validators.validate_user_id("-1001234567890")
+            '-1001234567890'
             >>> Validators.validate_user_id("abc")  # 抛出异常
         """
         if not user_id:
             raise ValidationError("用户ID不能为空")
         
-        user_id_str = str(user_id)
+        user_id_str = str(user_id).strip()
         
-        # 检查是否为数字
-        if not user_id_str.isdigit():
-            raise ValidationError("用户ID必须是数字")
+        # 处理前导负号（Telegram 用户ID为负数）
+        if user_id_str.startswith('-'):
+            numeric_part = user_id_str[1:]
+            if not numeric_part.isdigit():
+                raise ValidationError("用户ID必须是数字")
+        else:
+            numeric_part = user_id_str
+            if not numeric_part.isdigit():
+                raise ValidationError("用户ID必须是数字")
         
         # 检查长度 - 放宽限制，支持各种长度的用户ID
-        if len(user_id_str) < USER_ID_MIN_LENGTH or len(user_id_str) > USER_ID_MAX_LENGTH:
-            raise ValidationError(f"用户ID长度应在{USER_ID_MIN_LENGTH}-{USER_ID_MAX_LENGTH}位之间")
+        if len(numeric_part) < USER_ID_MIN_LENGTH or len(numeric_part) > USER_ID_MAX_LENGTH:
+            raise ValidationError(f"用户ID数字部分长度应在{USER_ID_MIN_LENGTH}-{USER_ID_MAX_LENGTH}位之间")
         
         return user_id_str
     


### PR DESCRIPTION
## 修复内容

### 1. 跨平台兼容性
- 创建 `utils/platform_helper.py` 统一处理不同平台的API差异
- 修复 Telegram 平台 `event.bot` 属性缺失的问题
- 修复 Discord 平台 `event.bot` 属性缺失的问题
- 统一群成员信息获取方式（`member.get("user_id")` → `PlatformHelper.get_user_id_from_member()`）

### 2. 负数ID支持
- 修复 `data_manager.py` 中 `update_user_message` 的 `group_id.isdigit()` 过滤掉负数ID的问题
- 修复 `validators.py` 中 `validate_user_id` 不支持负数的问题
- 修复 `timer_manager.py` 中 `group_id.isdigit()` 过滤掉负数ID的问题

### 3. Discord 兼容性
- 修复 `validate_group_id` 数字部分长度上限从15位放宽至20位（Discord群组ID为19位）

### 4. 定时推送优化
- 支持 `timer_target_groups` 中填写 `unified_msg_origin` 格式或纯群号
- 自动从 `unified_msg_origin` 中提取群组ID进行匹配
- 将缺少 unified_msg_origin 的提示从 WARN 改为 INFO 级别

### 5. 图片生成优化
- 修复 Playwright 页面渲染超时问题（`wait_until='networkidle'` → `wait_until='load'`）

## 修改的文件
- `main.py` - 跨平台兼容、unified_msg_origin匹配逻辑
- `utils/platform_helper.py` - 新增，统一跨平台兼容模块
- `utils/timer_manager.py` - 定时推送兼容性修复
- `utils/validators.py` - 负数ID和长ID支持
- `utils/image_generator.py` - 页面渲染超时修复
- `utils/data_manager.py` - 负数ID支持
