### PR TITLE
feat: Web 面板 UI 重构 + 主题跟随系统 + 多项体验优化

### DIFF
--- a/pages/overview/index.html
+++ b/pages/overview/index.html
@@ -1,1 +1,379 @@
-<!DOCTYPE html><html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>发言统计面板</title><style>:root{--bg:linear-gradient(135deg,#E9EFF6 0%,#D6E4F0 100%);--cb:rgba(255,255,255,0.55);--cb2:rgba(255,255,255,0.6);--cs:0 8px 32px rgba(0,0,0,0.08),inset 0 1px 0 rgba(255,255,255,0.7);--c:#1F2937;--c2:#6B7280;--c3:#9CA3AF;--l:rgba(229,231,235,0.6);--h:rgba(255,255,255,0.35);--n:#1F2937;--n2:#EF4444;--p:#22C55E;--tbg:rgba(59,130,246,0.15);--tc:#3B82F6;--dbg:rgba(239,68,68,0.12);--dc:#EF4444;--htbg:rgba(251,191,36,0.1);--htb:rgba(251,191,36,0.25);--htc:#B45309;--ttc:#7C3AED;--ttbg:#EDE9FE;--sb-w:300px}html[data-theme=dark]{--bg:linear-gradient(135deg,#2a2d3e 0%,#253247 100%);--cb:rgba(255,255,255,0.08);--cb2:rgba(255,255,255,0.1);--cs:0 8px 32px rgba(0,0,0,0.3),inset 0 1px 0 rgba(255,255,255,0.1);--c:#E5E7EB;--c2:#9CA3AF;--c3:#6B7280;--l:rgba(255,255,255,0.06);--h:rgba(255,255,255,0.06);--n:#F3F4F6;--n2:#F87171;--p:#4ADE80;--tbg:rgba(96,165,250,0.15);--tc:#93C5FD;--dbg:rgba(248,113,113,0.12);--dc:#FCA5A5;--htbg:rgba(251,191,36,0.08);--htb:rgba(251,191,36,0.2);--htc:#FBBF24;--ttc:#A78BFA;--ttbg:rgba(167,139,250,0.15)}*{margin:0;padding:0;box-sizing:border-box}BODY{font-family:'Microsoft YaHei','Segoe UI',sans-serif;background:var(--bg);color:var(--c);min-height:100vh;transition:background .3s,color .3s;display:flex;flex-direction:column}.hd{text-align:center;padding:24px 40px 0;flex-shrink:0}.hd H1{font-size:24px}.mn{display:flex;flex:1;padding:16px 40px 40px;gap:20px;min-height:0}.sb{width:var(--sb-w);flex-shrink:0;display:flex;flex-direction:column}.sb .c{flex:1;overflow-y:auto;margin:0}.sb .c H2{font-size:15px;padding:10px 14px 6px}.sb li{padding:12px 14px;flex-direction:column;align-items:stretch;gap:4px}.sb li:hover{transform:none}.sb li .A{font-size:14px}.sb li .B{font-size:12px}.sb li.sel{background:var(--tbg);border-radius:12px}.ct{flex:1;min-width:0;display:flex;flex-direction:column}.ct .c{flex:1;margin:0}.emp{flex:1;display:flex;align-items:center;justify-content:center;text-align:center;padding:40px;color:var(--c3);font-size:15px;background:var(--cb);backdrop-filter:blur(16px) saturate(140%);-webkit-backdrop-filter:blur(16px) saturate(140%);border-radius:20px;box-shadow:var(--cs);border:1px solid var(--cb2)}.c{background:var(--cb);backdrop-filter:blur(16px) saturate(140%);-webkit-backdrop-filter:blur(16px) saturate(140%);border-radius:20px;padding:16px;margin:20px 0;box-shadow:var(--cs);border:1px solid var(--cb2);overflow:hidden;transition:background .3s,border .3s,box-shadow .3s}.c H2{font-size:20px;color:var(--c);margin:0 0 16px;padding:12px 16px 8px;border-bottom:2px solid var(--l);transition:color .3s,border-color .3s}ul{list-style:none;padding:4px 0}li{display:flex;align-items:center;padding:16px;border-bottom:1px solid var(--l);cursor:pointer;transition:all .3s ease}li:last-child{border-bottom:none}li:hover{background:var(--h);transform:translateX(5px);border-radius:16px}li .l{flex:1;min-width:0}li .A{font-size:18px;font-weight:600;color:var(--n);transition:color .3s}li .B{font-size:13px;color:var(--c2);margin:4px 0 0}.rc{padding:4px 0}.ri{display:flex;align-items:center;padding:16px;border-bottom:1px solid var(--l);transition:all .3s ease}.ri:last-child{border-bottom:none}.ri:hover{background:var(--h);transform:translateX(5px);border-radius:16px}.av{width:60px;height:60px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;color:#fff;margin:0 25px 0 0;box-shadow:0 4px 8px rgba(0,0,0,.2);text-shadow:0 1px 3px rgba(0,0,0,.3);overflow:hidden}.ri2{flex:1;min-width:0}.ri2 .nn{font-size:20px;font-weight:600;color:var(--n);transition:color .3s}.ri2 .tt{font-size:12px;color:var(--ttc);font-weight:700;margin:0 0 0 6px;background:var(--ttbg);padding:0 6px;border-radius:6px;display:inline-block}.ri2 .dd{font-size:13px;color:var(--c2);margin:4px 0 0}.rs{text-align:right;flex-shrink:0;margin:0 0 0 20px}.rs .nn2{font-size:24px;font-weight:700;color:var(--n2)}.rs .pp{font-size:15px;color:var(--p);font-weight:500;margin:4px 0 0}.hi{text-align:center;padding:20px 16px;border-bottom:1px solid var(--l)}.hi .X{font-size:36px;font-weight:700;color:var(--n2)}.hi .y{font-size:14px;color:var(--c2);margin:6px 0 0}.hi .z{font-size:12px;color:var(--c3);margin:2px 0 0}.ht{border-radius:12px;background:var(--htbg);border:1px solid var(--htb);padding:10px 16px;margin:12px 0;font-size:13px;color:var(--htc);transition:background .3s,border-color .3s,color .3s}.tb{display:flex;gap:10px;align-items:center;flex-wrap:wrap}.tb .ht{margin:0;display:inline-flex;align-items:center;line-height:1.4}.dtb{display:inline-flex;align-items:center;padding:10px 18px;background:var(--dbg);color:var(--dc);border:none;border-radius:16px;font-size:13px;outline:none;cursor:pointer;transition:all .3s;line-height:1.4;white-space:nowrap}.dtb:hover{background:rgba(248,113,113,0.25);transform:translateX(3px)}html[data-theme=dark] .dtb:hover{background:rgba(248,113,113,0.3)}.ld{text-align:center;padding:80px 20px;color:var(--c3);font-size:16px}.em{text-align:center;padding:80px 20px;color:var(--c3)}.sb .ld{padding:40px 20px}#md{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;z-index:999}#md_in{background:var(--cb);backdrop-filter:blur(16px);border-radius:16px;padding:30px;max-width:400px;text-align:center;box-shadow:0 8px 40px rgba(0,0,0,.3);border:1px solid var(--cb2)}#md_msg{font-size:16px;font-weight:600;margin:0 0 20px;color:var(--n)}#md_btns{display:flex;gap:12px;justify-content:center}#md_btns button{padding:8px 24px;border:none;border-radius:12px;font-size:14px;cursor:pointer;outline:none}@media(max-width:800px){.mn{flex-direction:column;padding:12px 16px 24px;gap:12px}.sb{width:100%}.hd{padding:16px 16px 0}.hd H1{font-size:20px}.sb .c{max-height:260px}}</style></head><body><div class="hd"><h1>📊 发言统计面板</h1></div><div class="mn"><div class="sb" id="sidebar"><div class="c"><h2>选择群组</h2><ul id="gl"></ul></div></div><div class="ct" id="content"><div class="emp">👈 从左侧选择一个群组查看详情</div></div></div><div id="md"><div id="md_in"><div id="md_msg">确认删除？</div><div id="md_btns"><button id="md_no" style="background:rgba(128,128,128,0.15);color:var(--c)">取消</button><button id="md_yes" style="background:#EF4444;color:#fff">确认删除</button></div></div></div><script type="module">const B=window.AstrBotPluginPage;if(!B){document.querySelector('.emp').innerHTML='<div class="ld">Bridge not available</div>';document.body.style.display='flex'}else{await B.ready();(function(){const dm=window.matchMedia('(prefers-color-scheme:dark)');function st(d){document.documentElement.setAttribute('data-theme',d?'dark':'light')}st(dm.matches);dm.addEventListener('change',function(e){st(e.matches)})})();const GL=document.getElementById('gl'),CT=document.getElementById('content'),MD=document.getElementById('md'),MD_MSG=document.getElementById('md_msg'),MD_YES=document.getElementById('md_yes'),MD_NO=document.getElementById('md_no');let MD_CB=null,GD=[],SEL=null;MD_YES.onclick=function(){MD.style.display='none';if(MD_CB)MD_CB()};MD_NO.onclick=function(){MD.style.display='none'};MD.onclick=function(e){if(e.target===MD)MD.style.display='none'};function F(r){return r&&r.data?r.data:r}const pal=['#F59E0B','#3B82F6','#8B5CF6','#EC4899','#10B981','#EF4444','#14B8A6','#F97316','#6366F1','#84CC16','#06B6D4','#D946EF','#0EA5E9','#EAB308','#A855F7'];function getColor(s){let h=0;for(let i=0;i<s.length;i++){h=(h*31+s.charCodeAt(i))>>>0}return pal[h%pal.length]}function makeAvatar(n){const c=n&&n.trim()?n.trim()[0]:'?';return'<div class="av" style="background:'+getColor(n||'x')+'">'+c+'</div>'}function isDefault(n){return n&&n.startsWith('群')&&!n.includes(' - ')}function renderSidebar(){let h='';if(!GD||!GD.length){GL.innerHTML='<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">暂无群组数据</li>';return}GD.forEach(x=>{const dn=x.display_name||x.group_name||'群'+x.group_id,no=isDefault(dn),un=x.user_count||0,tm=x.total_messages||0,sel=SEL===x.group_id?' sel':'';h+='<li class="'+sel+'" data-gid="'+x.group_id+'"><div class="l"><div class="A'+(no?'" style="color:var(--htc)"':'')+'">'+(no?'⚠️ ':'')+dn+'</div><div class="B">'+un+' 人 · '+tm+' 条'+(x.file_size?' · '+x.file_size:'')+'</div></div></li>'});GL.innerHTML=h;GL.querySelectorAll('li[data-gid]').forEach(el=>{el.onclick=function(){enterGroup(this.dataset.gid)}})}function renderDetail(){const g=GD.find(x=>x.group_id===SEL);if(!g){CT.innerHTML='<div class="emp">👈 从左侧选择一个群组查看详情</div>';return}const u=g.top_users||[],dn=g.display_name||g.group_name||'群'+g.group_id,no=isDefault(dn),tm=g.total_messages||0,uc=g.user_count||0;let h='';h+='<div class="tb">';h+='<div style="flex:1;min-width:0"><div class="ht">'+(no?'⚠️ '+dn:dn)+'</div></div>';h+='<button class="dtb" id="delBtn">🗑️ 删除数据</button>';h+='</div>';h+='<div class="ht">💡 群名称会在触发发言榜后更新</div>';h+='<div class="c"><div class="hi"><div class="X">'+tm+'</div><div class="y">总发言数 · 共 '+uc+' 人</div><div class="z">ID: '+g.group_id+(g.file_size?' · 数据: '+g.file_size:'')+'</div></div><div class="rc">';if(u.length){h+=u.map((x,i)=>{const t=x.title?'<span class="tt">「'+x.title+'」</span>':'';return'<div class="ri">'+makeAvatar(x.nickname)+'<div class="ri2"><div class="nn">'+x.nickname+t+'</div><div class="dd">最近发言: '+(x.last_date||'未知')+'</div></div><div class="rs"><div class="nn2">'+x.message_count+'</div><div class="pp">'+x.percentage.toFixed(1)+'%</div></div></div>'}).join('')}else{h+='<div class="em" style="padding:40px 20px">暂无用户数据</div>'}h+='</div></div>';CT.innerHTML=h;const db=document.getElementById('delBtn');if(db){db.onclick=function(){MD_MSG.textContent='确定要删除此群组的所有发言数据吗？此操作不可恢复！';MD_CB=function(){B.apiGet('delete',{group_id:SEL}).then(function(){GD=GD.filter(x=>x.group_id!==SEL);SEL=null;renderSidebar();renderDetail()}).catch(function(){})};MD.style.display='flex'}}}function loadGroups(){GL.innerHTML='<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">加载中...</li>';B.apiGet('stats').then(r=>{const d=F(r),g=d&&d.groups?d.groups:null;if(g&&g.length){GD=g;renderSidebar();if(SEL){const still=GD.find(x=>x.group_id===SEL);if(!still){SEL=null;renderDetail()}else{enterGroup(SEL)}}else if(GD.length&&!SEL){SEL=GD[0].group_id;renderSidebar();enterGroup(SEL)}}else{GD=[];renderSidebar();CT.innerHTML='<div class="emp">暂无群组数据</div>'}}).catch(e=>{GL.innerHTML='<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">加载失败</li>';CT.innerHTML='<div class="emp">暂无群组数据</div>'})}function enterGroup(id){SEL=id;renderSidebar();CT.innerHTML='<div class="ld">加载中...</div>';B.apiGet('stats',{group_id:id}).then(r=>{const d=F(r),ng=d&&d.group?d.group:null;if(!ng){CT.innerHTML='<div class="emp">暂无数据</div>';return}const idx=GD.findIndex(x=>x.group_id===id);if(idx>-1){GD[idx]={...GD[idx],top_users:ng.top_users,total_messages:ng.total_messages,user_count:ng.user_count,file_size:ng.file_size,display_name:ng.display_name,group_name:ng.group_name}}renderDetail()}).catch(e=>{CT.innerHTML='<div class="emp">加载失败</div>'})}window.enterGroup=enterGroup;loadGroups()}</script></body></html>
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>发言统计面板</title>
+<style>
+:root {
+  --bg: linear-gradient(135deg,#E9EFF6 0%,#D6E4F0 100%);
+  --cb: rgba(255,255,255,0.55);
+  --cb2: rgba(255,255,255,0.6);
+  --cs: 0 8px 32px rgba(0,0,0,0.08), inset 0 1px 0 rgba(255,255,255,0.7);
+  --c: #1F2937;
+  --c2: #6B7280;
+  --c3: #9CA3AF;
+  --l: rgba(229,231,235,0.6);
+  --h: rgba(255,255,255,0.35);
+  --n: #1F2937;
+  --n2: #EF4444;
+  --p: #22C55E;
+  --tbg: rgba(59,130,246,0.15);
+  --tc: #3B82F6;
+  --dbg: rgba(239,68,68,0.12);
+  --dc: #EF4444;
+  --htbg: rgba(251,191,36,0.1);
+  --htb: rgba(251,191,36,0.25);
+  --htc: #B45309;
+  --ttc: #7C3AED;
+  --ttbg: #EDE9FE;
+  --sb-w: 300px;
+}
+html[data-theme=dark] {
+  --bg: linear-gradient(135deg,#2a2d3e 0%,#253247 100%);
+  --cb: rgba(255,255,255,0.08);
+  --cb2: rgba(255,255,255,0.1);
+  --cs: 0 8px 32px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.1);
+  --c: #E5E7EB;
+  --c2: #9CA3AF;
+  --c3: #6B7280;
+  --l: rgba(255,255,255,0.06);
+  --h: rgba(255,255,255,0.06);
+  --n: #F3F4F6;
+  --n2: #F87171;
+  --p: #4ADE80;
+  --tbg: rgba(96,165,250,0.15);
+  --tc: #93C5FD;
+  --dbg: rgba(248,113,113,0.12);
+  --dc: #FCA5A5;
+  --htbg: rgba(251,191,36,0.08);
+  --htb: rgba(251,191,36,0.2);
+  --htc: #FBBF24;
+  --ttc: #A78BFA;
+  --ttbg: rgba(167,139,250,0.15);
+}
+* { margin:0; padding:0; box-sizing:border-box }
+BODY {
+  font-family:'Microsoft YaHei','Segoe UI',sans-serif;
+  background:var(--bg); color:var(--c);
+  min-height:100vh; transition:background .3s,color .3s;
+  display:flex; flex-direction:column
+}
+.hd { text-align:center; padding:24px 40px 0; flex-shrink:0 }
+.hd H1 { font-size:24px }
+.mn { display:flex; flex:1; padding:16px 40px 40px; gap:20px; min-height:0 }
+.sb { width:var(--sb-w); flex-shrink:0; display:flex; flex-direction:column }
+.sb .c { flex:1; overflow:hidden; margin:0; display:flex; flex-direction:column }
+.sb .c H2 {
+  font-size:18px; text-align:center;
+  padding:16px 16px 8px; border-bottom:2px solid var(--l); margin:0
+}
+.sb-hint {
+  text-align:center; font-size:11px; color:var(--c3);
+  padding:8px 16px 6px; line-height:1.4
+}
+.sb .ul-wrap { flex:1; overflow-y:auto; padding:4px 8px }
+.sb li {
+  padding:14px 16px; flex-direction:column;
+  align-items:stretch; gap:6px; border-bottom:1px solid var(--l)
+}
+.sb li:last-child { border-bottom:none }
+.sb li:hover { transform:translateX(3px); border-radius:10px }
+.sb li .A { font-size:14px }
+.sb li .B { font-size:12px }
+.sb li.sel { background:var(--tbg); border-radius:10px }
+.ct { flex:1; min-width:0; display:flex; flex-direction:column }
+.ct .c { flex:1; margin:0 }
+.emp {
+  flex:1; display:flex; align-items:center; justify-content:center;
+  text-align:center; padding:40px; color:var(--c3); font-size:15px;
+  background:var(--cb); backdrop-filter:blur(16px) saturate(140%);
+  -webkit-backdrop-filter:blur(16px) saturate(140%);
+  border-radius:20px; box-shadow:var(--cs); border:1px solid var(--cb2)
+}
+.c {
+  padding:0; background:var(--cb);
+  backdrop-filter:blur(16px) saturate(140%);
+  -webkit-backdrop-filter:blur(16px) saturate(140%);
+  border-radius:20px; margin:20px 0; box-shadow:var(--cs);
+  border:1px solid var(--cb2); overflow:hidden;
+  transition:background .3s,border .3s,box-shadow .3s; position:relative
+}
+.c-top { position:absolute; top:10px; right:10px; z-index:1 }
+.del-corner {
+  display:inline-flex; align-items:center; padding:8px 16px;
+  background:var(--dbg); color:var(--dc); border:none; border-radius:16px;
+  font-size:13px; outline:none; cursor:pointer; transition:all .3s;
+  line-height:1.4; white-space:nowrap
+}
+.del-corner:hover { background:rgba(248,113,113,0.25) }
+html[data-theme=dark] .del-corner:hover { background:rgba(248,113,113,0.3) }
+.gn {
+  text-align:center; padding:28px 20px 8px; font-size:20px;
+  font-weight:700; color:var(--n); line-height:1.5; word-break:break-all
+}
+ul { list-style:none; padding:4px 0 }
+li {
+  display:flex; align-items:center; padding:16px;
+  border-bottom:1px solid var(--l); cursor:pointer; transition:all .3s ease
+}
+li:last-child { border-bottom:none }
+li:hover { background:var(--h); transform:translateX(5px); border-radius:16px }
+li .l { flex:1; min-width:0 }
+li .A { font-size:18px; font-weight:600; color:var(--n); transition:color .3s }
+li .B { font-size:13px; color:var(--c2); margin:4px 0 0 }
+.rc { padding:4px 0 }
+.ri {
+  display:flex; align-items:center; padding:16px;
+  border-bottom:1px solid var(--l); transition:all .3s ease
+}
+.ri:last-child { border-bottom:none }
+.ri:hover { background:var(--h); transform:translateX(5px); border-radius:16px }
+.av {
+  width:60px; height:60px; border-radius:50%; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center;
+  font-size:22px; font-weight:700; color:#fff; margin:0 25px 0 0;
+  box-shadow:0 4px 8px rgba(0,0,0,.2);
+  text-shadow:0 1px 3px rgba(0,0,0,.3); overflow:hidden
+}
+.ri2 { flex:1; min-width:0 }
+.ri2 .nn { font-size:20px; font-weight:600; color:var(--n); transition:color .3s }
+.ri2 .tt {
+  font-size:12px; color:var(--ttc); font-weight:700; margin:0 0 0 6px;
+  background:var(--ttbg); padding:0 6px; border-radius:6px; display:inline-block
+}
+.ri2 .dd { font-size:13px; color:var(--c2); margin:4px 0 0 }
+.rs { text-align:right; flex-shrink:0; margin:0 0 0 20px }
+.rs .nn2 { font-size:24px; font-weight:700; color:var(--n2) }
+.rs .pp { font-size:15px; color:var(--p); font-weight:500; margin:4px 0 0 }
+.hi { text-align:center; padding:16px 16px 20px; border-bottom:1px solid var(--l) }
+.hi .X { font-size:36px; font-weight:700; color:var(--n2) }
+.hi .y { font-size:14px; color:var(--c2); margin:6px 0 0 }
+.hi .z { font-size:12px; color:var(--c3); margin:2px 0 0 }
+.ld { text-align:center; padding:80px 20px; color:var(--c3); font-size:16px }
+.em { text-align:center; padding:80px 20px; color:var(--c3) }
+.sb .ld { padding:40px 20px }
+#md {
+  position:fixed; top:0; left:0; width:100%; height:100%;
+  background:rgba(0,0,0,0.5); display:none; align-items:center;
+  justify-content:center; z-index:999
+}
+#md_in {
+  background:var(--cb); backdrop-filter:blur(16px);
+  border-radius:16px; padding:30px; max-width:400px; text-align:center;
+  box-shadow:0 8px 40px rgba(0,0,0,.3); border:1px solid var(--cb2)
+}
+#md_msg { font-size:16px; font-weight:600; margin:0 0 20px; color:var(--n) }
+#md_btns { display:flex; gap:12px; justify-content:center }
+#md_btns button {
+  padding:8px 24px; border:none; border-radius:12px;
+  font-size:14px; cursor:pointer; outline:none
+}
+@media(max-width:800px) {
+  .mn { flex-direction:column; padding:12px 16px 24px; gap:12px }
+  .sb { width:100% }
+  .hd { padding:16px 16px 0 }
+  .hd H1 { font-size:20px }
+  .sb .ul-wrap { max-height:260px }
+}
+</style>
+</head>
+<body>
+
+<div class="hd"><h1>📊 发言统计面板</h1></div>
+
+<div class="mn">
+  <div class="sb" id="sidebar">
+    <div class="c">
+      <h2>选择群组</h2>
+      <div class="sb-hint">💡 群名称会在触发发言榜后更新</div>
+      <div class="ul-wrap"><ul id="gl"></ul></div>
+    </div>
+  </div>
+  <div class="ct" id="content">
+    <div class="emp">👈 从左侧选择一个群组查看详情</div>
+  </div>
+</div>
+
+<div id="md">
+  <div id="md_in">
+    <div id="md_msg">确认删除？</div>
+    <div id="md_btns">
+      <button id="md_no" style="background:rgba(128,128,128,0.15);color:var(--c)">取消</button>
+      <button id="md_yes" style="background:#EF4444;color:#fff">确认删除</button>
+    </div>
+  </div>
+</div>
+
+<script type="module">
+const B = window.AstrBotPluginPage;
+if (!B) {
+  document.querySelector('.emp').innerHTML = '<div class="ld">Bridge not available</div>';
+  document.body.style.display = 'flex';
+} else {
+  await B.ready();
+
+  // 主题跟随系统
+  (function() {
+    const dm = window.matchMedia('(prefers-color-scheme:dark)');
+    function st(d) { document.documentElement.setAttribute('data-theme', d ? 'dark' : 'light'); }
+    st(dm.matches);
+    dm.addEventListener('change', function(e) { st(e.matches); });
+  })();
+
+  const GL = document.getElementById('gl');
+  const CT = document.getElementById('content');
+  const MD = document.getElementById('md');
+  const MD_MSG = document.getElementById('md_msg');
+  const MD_YES = document.getElementById('md_yes');
+  const MD_NO = document.getElementById('md_no');
+  let MD_CB = null, GD = [], SEL = null;
+
+  MD_YES.onclick = function() { MD.style.display = 'none'; if (MD_CB) MD_CB(); };
+  MD_NO.onclick = function() { MD.style.display = 'none'; };
+  MD.onclick = function(e) { if (e.target === MD) MD.style.display = 'none'; };
+
+  function F(r) { return r && r.data ? r.data : r; }
+
+  const pal = ['#F59E0B','#3B82F6','#8B5CF6','#EC4899','#10B981','#EF4444','#14B8A6','#F97316','#6366F1','#84CC16','#06B6D4','#D946EF','#0EA5E9','#EAB308','#A855F7'];
+  function getColor(s) {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) >>> 0; }
+    return pal[h % pal.length];
+  }
+  function makeAvatar(n) {
+    const c = n && n.trim() ? n.trim()[0] : '?';
+    return '<div class="av" style="background:' + getColor(n || 'x') + '">' + c + '</div>';
+  }
+  function isDefault(n) { return n && n.startsWith('群') && !n.includes(' - '); }
+
+  function renderSidebar() {
+    let h = '';
+    if (!GD || !GD.length) {
+      GL.innerHTML = '<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">暂无群组数据</li>';
+      return;
+    }
+    GD.forEach(function(x) {
+      const dn = x.display_name || x.group_name || '群' + x.group_id;
+      const no = isDefault(dn);
+      const un = x.user_count || 0;
+      const tm = x.total_messages || 0;
+      const sel = SEL === x.group_id ? ' sel' : '';
+      h += '<li class="' + sel + '" data-gid="' + x.group_id + '">'
+         +   '<div class="l">'
+         +     '<div class="A' + (no ? '" style="color:var(--htc)"' : '') + '">' + (no ? '⚠️ ' : '') + dn + '</div>'
+         +     '<div class="B">' + un + ' 人 · ' + tm + ' 条' + (x.file_size ? ' · ' + x.file_size : '') + '</div>'
+         +   '</div>'
+         + '</li>';
+    });
+    GL.innerHTML = h;
+    GL.querySelectorAll('li[data-gid]').forEach(function(el) {
+      el.onclick = function() { enterGroup(this.dataset.gid); };
+    });
+  }
+
+  function renderDetail() {
+    const g = GD.find(function(x) { return x.group_id === SEL; });
+    if (!g) {
+      CT.innerHTML = '<div class="emp">👈 从左侧选择一个群组查看详情</div>';
+      return;
+    }
+    const u = g.top_users || [];
+    const dn = g.display_name || g.group_name || '群' + g.group_id;
+    const no = isDefault(dn);
+    const tm = g.total_messages || 0;
+    const uc = g.user_count || 0;
+    let h = '';
+    h += '<div class="c">'
+      +   '<div class="c-top"><button class="del-corner" id="delBtn">🗑️ 删除数据</button></div>'
+      +   '<div class="gn">' + (no ? '⚠️ ' : '') + g.group_name + '[' + g.group_id + ']</div>'
+      +   '<div class="hi">'
+      +     '<div class="X">' + tm + '</div>'
+      +     '<div class="y">总发言数 · 共 ' + uc + ' 人</div>'
+      +     '<div class="z">ID: ' + g.group_id + (g.file_size ? ' · 数据: ' + g.file_size : '') + '</div>'
+      +   '</div>'
+      +   '<div class="rc">';
+    if (u.length) {
+      h += u.map(function(x) {
+        const t = x.title ? '<span class="tt">「' + x.title + '」</span>' : '';
+        return '<div class="ri">'
+             +   makeAvatar(x.nickname)
+             +   '<div class="ri2">'
+             +     '<div class="nn">' + x.nickname + t + '</div>'
+             +     '<div class="dd">最近发言: ' + (x.last_date || '未知') + '</div>'
+             +   '</div>'
+             +   '<div class="rs">'
+             +     '<div class="nn2">' + x.message_count + '</div>'
+             +     '<div class="pp">' + x.percentage.toFixed(1) + '%</div>'
+             +   '</div>'
+             + '</div>';
+      }).join('');
+    } else {
+      h += '<div class="em" style="padding:40px 20px">暂无用户数据</div>';
+    }
+    h += '</div></div>';
+    CT.innerHTML = h;
+    const db = document.getElementById('delBtn');
+    if (db) {
+      db.onclick = function() {
+        MD_MSG.textContent = '确定要删除此群组的所有发言数据吗？此操作不可恢复！';
+        MD_CB = function() {
+          B.apiGet('delete', { group_id: SEL }).then(function() {
+            GD = GD.filter(function(x) { return x.group_id !== SEL; });
+            SEL = null; renderSidebar(); renderDetail();
+          }).catch(function() {});
+        };
+        MD.style.display = 'flex';
+      };
+    }
+  }
+
+  function loadGroups() {
+    GL.innerHTML = '<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">加载中...</li>';
+    B.apiGet('stats').then(function(r) {
+      const d = F(r), g = d && d.groups ? d.groups : null;
+      if (g && g.length) {
+        GD = g; renderSidebar();
+        if (SEL) {
+          const still = GD.find(function(x) { return x.group_id === SEL; });
+          if (!still) { SEL = null; renderDetail(); }
+          else { enterGroup(SEL); }
+        } else if (GD.length && !SEL) {
+          SEL = GD[0].group_id; renderSidebar(); enterGroup(SEL);
+        }
+      } else {
+        GD = []; renderSidebar();
+        CT.innerHTML = '<div class="emp">暂无群组数据</div>';
+      }
+    }).catch(function(e) {
+      GL.innerHTML = '<li style="cursor:default;color:var(--c3);justify-content:center;padding:40px 14px;border:none">加载失败</li>';
+      CT.innerHTML = '<div class="emp">暂无群组数据</div>';
+    });
+  }
+
+  function enterGroup(id) {
+    SEL = id; renderSidebar();
+    CT.innerHTML = '<div class="ld">加载中...</div>';
+    B.apiGet('stats', { group_id: id }).then(function(r) {
+      const d = F(r), ng = d && d.group ? d.group : null;
+      if (!ng) { CT.innerHTML = '<div class="emp">暂无数据</div>'; return; }
+      const idx = GD.findIndex(function(x) { return x.group_id === id; });
+      if (idx > -1) {
+        GD[idx] = Object.assign({}, GD[idx], {
+          top_users: ng.top_users, total_messages: ng.total_messages,
+          user_count: ng.user_count, file_size: ng.file_size,
+          display_name: ng.display_name, group_name: ng.group_name
+        });
+      }
+      renderDetail();
+    }).catch(function(e) {
+      CT.innerHTML = '<div class="emp">加载失败</div>';
+    });
+  }
+
+  window.enterGroup = enterGroup;
+  loadGroups();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
**描述：**
### 变更概述

对 Web 数据管理面板进行了全面 UI 重构和体验优化，涵盖布局改造、主题适配、交互细节等多项改进。

### 变更内容

**1. 布局重构：左-右侧边栏布局**
- 原上下翻页式改为左侧群组侧边栏（300px）+ 右侧详情区布局
- 进入页面默认选中第一个群组，无需手动点击
- 侧边栏「选择群组」标题居中显示，字体调大
- 💡 提示以小字显示在侧边栏标题下方
- 群列表内边距优化，选中高亮，悬停效果

**2. 卡片详情区优化**
- 群名称（格式：`群名称[群ID]`）居中嵌入卡片内，置于发言总数上方，字号 20px 加粗
- 删除按钮改为全圆角气泡，置于卡片右上角（与卡片圆角同心对齐）
- 删除群组数据后自动回到空状态

**3. 主题跟随系统深色/浅色模式**
- 将 `@media(prefers-color-scheme)` 方案升级为 `:root + html[data-theme]` CSS 变量方案
- 添加 `matchMedia` 监听系统主题变化实时自动切换
- 所有颜色值（背景、卡片、文字、按钮、提示、头衔标签等）均使用 CSS 变量
- 暗色模式下正确适配，0.3s 过渡动画，切换更平滑

**4. 其他修复**
- 修复 Web 面板返回按钮无效、用户缺少头像、删除按钮不工作等问题
- 按钮颜色在暗色模式下自适应亮色，不再看不清

### 涉及文件
- `pages/overview/index.html` — 全部 UI 重构
- `main.py` — 注册 Web API
- `metadata.yaml` — 版本号更新
- `CHANGELOG.md` — 变更记录