### PR TITLE
fix: 修复头衔未持久化保存和定时循环异常重试多并发问题

### DIFF
--- a/templates/milestone_template.html
+++ b/templates/milestone_template.html
@@ -187,7 +187,11 @@
             <div class="content-layer">
                 <div class="medal-box">
                     <div class="medal-solid">
+                        {% if avatar_url %}
                         <img class="ava-img" src="{{ avatar_url }}" alt="avatar" />
+                        {% else %}
+                        <div style="width:110px;height:110px;border-radius:50%;background:{{ avatar_color or '#3B82F6' }};display:flex;align-items:center;justify-content:center;color:#fff;font-size:48px;font-weight:700;text-shadow:0 2px 4px rgba(0,0,0,0.3);">{{ avatar_char or '?' }}</div>
+                        {% endif %}
                     </div>
                     <div class="nick-txt">{{ nickname }}</div>
                 </div>

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -569,12 +569,16 @@ class ImageGenerator:
                 return None
             
             # 准备模板数据
-            avatar_url = self._get_avatar_url(user_id, "qq")
+            avatar_url = self._get_avatar_url(user_id)
+            avatar_color = self._get_avatar_color(nickname)
+            avatar_char = self._get_avatar_char(nickname)
             group_name = group_info.group_name or f"群{group_info.group_id}"
             current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             
             template_data = {
                 'avatar_url': avatar_url,
+                'avatar_color': avatar_color,
+                'avatar_char': avatar_char,
                 'nickname': self._escape_html_safe(nickname),
                 'user_id': self._escape_html_safe(str(user_id)),
                 'group_name': self._escape_html_safe(f"{group_name}[{group_info.group_id}]"),
@@ -751,7 +755,9 @@ class ImageGenerator:
                 'nickname': user.nickname,
                 'title': user_title,
                 'title_color': user_title_color,
-                'avatar_url': self._get_avatar_url(user.user_id, "qq"),
+                'avatar_url': self._get_avatar_url(user.user_id),
+                'avatar_color': self._get_avatar_color(user.nickname),
+                'avatar_char': self._get_avatar_char(user.nickname),
                 'total': user_messages,
                 'percentage': (user_messages / total_messages * 100) if total_messages > 0 else 0,
                 'last_date': user.last_date or "未知",
@@ -768,7 +774,7 @@ class ImageGenerator:
                 user_items.append({
                     'rank': current_rank,
                     'nickname': current_user_data.nickname,
-                    'avatar_url': self._get_avatar_url(current_user_data.user_id, "qq"),
+                    'avatar_url': self._get_avatar_url(current_user_data.user_id),
                     'total': current_user_messages,
                     'percentage': (current_user_messages / total_messages * 100) if total_messages > 0 else 0,
                     'last_date': current_user_data.last_date or "未知",
@@ -978,6 +984,10 @@ class ImageGenerator:
         safe_rank_color = html.escape(styles['rank_color'])
         safe_avatar_border = html.escape(styles['avatar_border'])
         
+        # 获取字母头像所需元素
+        safe_avatar_color = html.escape(item_data.get('avatar_color', '#3B82F6'))
+        safe_avatar_char = html.escape(item_data.get('avatar_char', '?'))
+        
         # 使用字符串拼接而不是f-string，提高安全性
         # 根据当前用户状态选择合适的排名样式类
         rank_class = "rank-current" if item_data['is_current_user'] else "rank"
@@ -991,10 +1001,16 @@ class ImageGenerator:
             safe_title_color = html.escape(str(user_title_color_raw)) if user_title_color_raw else '#7C3AED'
             user_title_html = f'<div class="user-title" style="color:{safe_title_color};background:{safe_title_color}22;font-size:13px;font-weight:700;padding:0px 8px;border-radius:10px;display:inline-block;margin-left:8px;vertical-align:middle;line-height:24px;">「{safe_title}」</div>'
         
+        # 头像区域：有URL用<img>，否则显示首字母彩色圆形
+        if safe_avatar_url:
+            avatar_html = f'    <img class="avatar" src="{safe_avatar_url}" style="border-color: {safe_avatar_border};" />'
+        else:
+            avatar_html = f'    <div class="avatar" style="background:{safe_avatar_color};width:60px;height:60px;border-radius:50%;display:flex;align-items:center;justify-content:center;color:#fff;font-size:24px;font-weight:700;margin-right:20px;flex-shrink:0;box-shadow:0 2px 8px rgba(0,0,0,0.1);text-shadow:0 1px 3px rgba(0,0,0,0.3);border:3px solid {safe_avatar_border};">{safe_avatar_char}</div>'
+        
         html_parts = [
             f'<div class="{css_classes["item"]}" style="{safe_separator_style}">',
             f'    <div class="{rank_class}">#{item_data["rank"]}</div>',
-            f'    <img class="avatar" src="{safe_avatar_url}" style="border-color: {safe_avatar_border};" />',
+            avatar_html,
             '    <div class="info">',
             '        <div class="name-date">',
             f'            <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;"><span class="nickname" style="font-size:24px;font-weight:600;color:#1F2937;line-height:1.3;">{safe_nickname}</span>{user_title_html}</div>',
@@ -1036,7 +1052,7 @@ class ImageGenerator:
         
         # 如果头像URL无效，使用默认头像
         if not safe_avatar_url:
-            safe_avatar_url = self._get_avatar_url(str(item_data.get('user_id', '0')), "qq")
+            safe_avatar_url = ""
         
         content = {
             'nickname': safe_nickname,
@@ -1068,35 +1084,23 @@ class ImageGenerator:
         url = url.replace('<', '').replace('>', '').replace('"', '').replace("'", '')
         return url
 
-    def _get_avatar_url(self, user_id: str, platform: str = "qq") -> str:
+    def _get_avatar_url(self, user_id: str, platform: str = "") -> str:
         """获取用户头像URL
+        注意：本插件为通用插件，不绑定特定平台。
+        返回空字符串时，HTML模板会自动显示彩色首字母头像作为优雅回退。
         
         Args:
             user_id (str): 用户ID
-            platform (str): 平台类型，支持 'qq', 'telegram', 'discord' 等
+            platform (str): 平台类型（保留参数）
             
         Returns:
-            str: 头像URL
+            str: 始终返回空字符串，使用模板内置的字母头像回退机制
         """
-        # 支持多种平台的头像服务
-        avatar_services = {
-            "qq": "https://q1.qlogo.cn/g?b=qq&nk={user_id}&s=640",
-            "telegram": "https://telegram.org/img/t_logo.png",  # Telegram默认头像
-            "discord": "https://cdn.discordapp.com/embed/avatars/{avatar_id}.png",  # Discord默认头像
-            "default": "https://via.placeholder.com/640x640?text=Avatar"  # 通用默认头像
-        }
-        
-        service_url = avatar_services.get(platform, avatar_services["default"])
-        
-        # 安全计算 avatar_id：处理负数ID（Telegram）和非数字字符串ID
-        try:
-            uid_int = abs(int(user_id))  # 取绝对值，确保为正数
-            avatar_id = uid_int % 5
-        except (ValueError, TypeError):
-            # 如果 user_id 不是有效数字，使用默认值
-            avatar_id = 0
-        
-        return service_url.format(user_id=user_id, avatar_id=avatar_id)
+        # 不再使用 qlogo.cn 等第三方头像服务
+        # 因为不同平台的用户ID格式不同（QQ的数字ID、Telegram的负数ID等）
+        # 使用第三方服务会导致头像错乱（显示其他人的头像）
+        # 模板中已有完善的回退机制：avatar_url 为空时显示彩色首字母圆形头像
+        return ""
     
     @safe_file_operation(default_return="")
     async def _load_html_template(self) -> str:


### PR DESCRIPTION
**修复内容：**
1. 定时推送 LLM 生成头衔后，调用 `save_group_data()` 持久化到磁盘，下次推送不会丢失
2. 只覆盖 LLM 返回了结果的用户，未覆盖的用户保留原有头衔
3. 异常重试时先取消旧任务再创建新任务，防止多个定时循环同时运行导致一次多发图