### PR TITLE
fix: 修复定时推送排行榜类型硬编码问题，优化 LLM 头衔调用逻辑，清理冗余依赖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # 更新日志
 
+## v1.9.4 (2026-05-09)
+
+### 🐛 Bug 修复
+
+- **定时/手动推送排行榜类型硬编码**：`_push_to_group()` 中硬编码 `RankType.DAILY`，导致用户在 WebUI 设置的 `timer_rank_type` 配置完全无效。已修复：改为读取 `config.timer_rank_type`，定时推送和手动推送均可使用用户配置的排行榜类型。
+- **`#手动推送发言榜` 群组ID格式解析错误**：当 `timer_target_groups` 中存储 `Amy:GroupMessage:1081839722` 格式时，`manual_push()` 直接传入 `_push_to_group()` 导致 `get_group_data()` 校验失败。已修复：统一添加 unified_msg_origin 格式的群组 ID 提取逻辑。
+- **LLM 头衔生成重复调用浪费 Tokens**：`_push_to_group()` 中先对全体用户调用 `llm_analyzer.analyze_users()` 后才筛选已有持久化头衔的用户，导致每次推送都浪费一次 LLM 调用。已修复：先筛选出无头衔用户，只对这部分用户调用 LLM。
+
+### 🧹 代码清理
+
+- **移除冗余 `pydantic` 依赖**：插件中未使用 pydantic，且 AstrBot 框架已自带，`requirements.txt` 中已移除。
+- **`metadata.yaml` 添加 `astrbot_version` 声明**：添加 `astrbot_version: ">=4.16"`，确保版本兼容性检查。
+
 ## v1.9.3 (2026-05-07)
 
 ### 🔐 安全改进

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ from .utils.constants import (
 # 导入统一异常处理器，简化命令方法的异常处理
 from .utils.exception_handlers import ExceptionHandler
 
-@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.3")
+@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.4")
 
 class MessageStatsPlugin(Star):
     """群发言统计插件

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,7 @@ short_description: "统计群成员发言次数，支持多种排行榜和定时
 version: "1.9.3"
 
 repo: "https://github.com/xiaoruange39/astrbot_plugin_message_stats"
+astrbot_version: ">=4.16"
 support_platforms:
   - aiocqhttp
   - telegram

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display_name: AstrBot 群发言统计插件
 author: "xiaoruange39 & AMYdd00"
 description: "QQ群消息统计插件，支持消息数量统计和排行榜生成"
 short_description: "统计群成员发言次数，支持多种排行榜和定时推送"
-version: "1.9.3"
+version: "1.9.4"
 
 repo: "https://github.com/xiaoruange39/astrbot_plugin_message_stats"
 astrbot_version: ">=4.16"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ jinja2>=3.1.0
 # 异步文件操作
 aiofiles>=24.1.0
 
-# 数据验证和处理
-pydantic>=2.8.0
-
 # 图片生成
 playwright>=1.45.0
 

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -781,7 +781,7 @@ class TimerManager:
         
         # 根据排行榜类型筛选数据
         # 定时推送强制使用今日排行榜
-        rank_type = RankType.DAILY
+        rank_type = self._parse_rank_type(config.timer_rank_type)
         filtered_data = await self._filter_data_by_rank_type(group_data, rank_type)
         if not filtered_data:
 

--- a/utils/timer_manager.py
+++ b/utils/timer_manager.py
@@ -711,15 +711,6 @@ class TimerManager:
                     max_retries=max_retries
                 )
                 
-                # 获取群组名称用于提示词
-                grp_name = await self._get_group_name(group_id)
-                titles, token_usage = await llm_analyzer.analyze_users(
-                    group_data, grp_name, min_daily_messages=min_daily
-                )
-                
-                if token_usage and token_usage.get("total_tokens", 0) > 0:
-                    token_usage_info = token_usage
-                
                 # 筛选出还没有持久化头衔的用户，已有头衔的用户跳过LLM分析
                 users_need_llm = [u for u in group_data if u.message_count > 0 and not u.llm_title]
                 users_with_title = [u for u in group_data if u.llm_title]
@@ -731,6 +722,7 @@ class TimerManager:
                 token_usage = None
                 if users_need_llm:
                     self.logger.info(f"为 {len(users_need_llm)} 个无头衔用户调用LLM生成头衔")
+                    grp_name = await self._get_group_name(group_id)
                     titles, token_usage = await llm_analyzer.analyze_users(
                         users_need_llm, grp_name, min_daily_messages=min_daily
                     )
@@ -1237,7 +1229,16 @@ class TimerManager:
                 # 推送到所有配置群组
                 success_count = 0
                 for target_group in config.timer_target_groups:
-                    if await self._push_to_group(target_group, config):
+                    group_id_str = str(target_group).strip()
+                    actual_group_id = group_id_str
+                    if ':' in group_id_str:
+                        try:
+                            extracted = group_id_str.rsplit(':', 1)[-1]
+                            if extracted.lstrip('-').isdigit():
+                                actual_group_id = extracted
+                        except (AttributeError, IndexError, ValueError):
+                            pass
+                    if await self._push_to_group(actual_group_id, config):
                         success_count += 1
                 
                 return success_count > 0


### PR DESCRIPTION
## 修复内容

### 🐛 Bug 修复

1. **定时/手动推送始终使用"今日排行榜"，忽略用户配置**
   - `_push_to_group` 中硬编码 `rank_type = RankType.DAILY`，导致用户在 WebUI 设置的 `timer_rank_type`（weekly/monthly/total/yearly 等）完全无效
   - 修复：改为读取 `config.timer_rank_type`，定时推送和手动推送均可使用用户配置的排行榜类型

2. **LLM 头衔生成重复调用浪费 Tokens**
   - `_push_to_group` 中先对全体用户调用了 `llm_analyzer.analyze_users()`，然后才筛选已有持久化头衔的用户，导致每次推送都浪费一次 LLM 调用
   - 修复：先筛选出无头衔用户，只对这部分用户调用 LLM

3. **`#手动推送发言榜` 报错 `群组ID必须是数字字符串`**
   - `config.timer_target_groups` 中存储的是 `Amy:GroupMessage:1081839722` 格式时，`manual_push` 直接传入 `_push_to_group` 导致 `get_group_data()` 校验失败
   - 修复：统一添加 unified_msg_origin 格式的群组 ID 提取逻辑（`_execute_push_task` 已有此逻辑，`manual_push` 缺失）

### 🧹 代码清理

- 移除 `requirements.txt` 中冗余的 `pydantic>=2.8.0` 依赖（AstrBot 框架已自带）
- `metadata.yaml` 添加 `astrbot_version: ">=4.16"` 声明，确保版本兼容性检查