### PR TITLE
fix: 修复 `#设置发言榜数量` 报错 & `_conf_schema.json` 排行榜输出模式选项不可选

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 更新日志
 
+## v1.9.8 (2026-05-10)
+
+### 🐛 Bug 修复
+
+- **修复 `#设置发言榜数量` 命令报错**：`MAX_RANK_COUNT` 类常量缺失导致 `self.MAX_RANK_COUNT` 触发 `AttributeError`，现已补全
+- **修复 WebUI 排行榜输出模式选项不可选**：`_conf_schema.json` 中 `if_send_pic` 使用了不支持的 `value`/`label` 对象格式且 `default` 类型不匹配，改用标准 `options` 数组格式
+
 ## v1.9.7 (2026-05-10)
 
 ### ✨ 新功能

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,17 +49,8 @@
     "type": "string",
     "description": "排行榜输出模式",
     "hint": "选择排行榜的展示方式，图片模式更美观但消耗更多资源",
-    "default": 1,
-    "options": [
-      {
-        "value": 0,
-        "label": "文字"
-      },
-      {
-        "value": 1,
-        "label": "图片"
-      }
-    ]
+    "default": "图片",
+    "options": ["文字", "图片"]
   },
   "timer_enabled": {
     "type": "bool",

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ from .utils.constants import (
 # 导入统一异常处理器，简化命令方法的异常处理
 from .utils.exception_handlers import ExceptionHandler
 
-@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.7")
+@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.8")
 
 class MessageStatsPlugin(Star):
     """群发言统计插件
@@ -534,7 +534,7 @@ class MessageStatsPlugin(Star):
     
     # 排行榜数量限制常量（使用模块级常量）
     RANK_COUNT_MIN = 1
-    # MAX_RANK_COUNT 已从 constants 模块导入，不再重复定义
+    MAX_RANK_COUNT = 100  # 最大排行榜显示人数，来源: constants.MAX_RANK_COUNT
     
     # 图片模式别名常量
     IMAGE_MODE_ENABLE_ALIASES = {'1', 'true', '开', 'on', 'yes'}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display_name: AstrBot 群发言统计插件
 author: "xiaoruange39 & AMYdd00"
 description: "QQ群消息统计插件，支持消息数量统计和排行榜生成"
 short_description: "统计群成员发言次数，支持多种排行榜和定时推送"
-version: "1.9.7"
+version: "1.9.8"
 
 
 repo: "https://github.com/xiaoruange39/astrbot_plugin_message_stats"


### PR DESCRIPTION
## PR 描述

### 🐛 Bug 修复

**1. 修复 `#设置发言榜数量` 命令报错**

`main.py` 中 `MAX_RANK_COUNT` 仅在模块顶部从 `constants` 导入为模块级变量，未定义为类常量。`set_rank_count()` 方法中通过 `self.MAX_RANK_COUNT` 访问时触发 `AttributeError`。

修复：在类常量区域添加 `MAX_RANK_COUNT = 100`。

**2. 修复 WebUI 排行榜输出模式选项不可选**

`_conf_schema.json` 中 `if_send_pic` 有两个问题：

- `options` 使用了 `[{value, label}]` 对象格式，AstrBot WebUI 不支持，导致渲染为空
- `type` 为 `"string"` 但 `default: 1` 为整数类型，类型不匹配

修复：改用标准 `options: ["文字", "图片"]` 数组格式，`default: "图片"` 字符串。

### 🔖 其他

- 版本号从 `1.9.7` → `1.9.8`
- CHANGELOG 更新