### PR TITLE
fix: llm_title_message_count 未定义导致 LLM 头衔报错

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 更新日志
 
+## v1.9.8 (2026-05-10)
+
+### 🐛 Bug 修复
+
+- **修复 `#设置发言榜数量` 命令报错**：`MAX_RANK_COUNT` 类常量缺失导致 `self.MAX_RANK_COUNT` 触发 `AttributeError`，现已补全
+- **修复 WebUI 排行榜输出模式选项不可选**：`_conf_schema.json` 中 `if_send_pic` 使用了不支持的 `value`/`label` 对象格式且 `default` 类型不匹配，改用标准 `options` 数组格式
+
 ## v1.9.7 (2026-05-10)
 
 ### ✨ 新功能

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,17 +49,8 @@
     "type": "string",
     "description": "排行榜输出模式",
     "hint": "选择排行榜的展示方式，图片模式更美观但消耗更多资源",
-    "default": 1,
-    "options": [
-      {
-        "value": 0,
-        "label": "文字"
-      },
-      {
-        "value": 1,
-        "label": "图片"
-      }
-    ]
+    "default": "图片",
+    "options": ["文字", "图片"]
   },
   "timer_enabled": {
     "type": "bool",

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ from .utils.constants import (
 # 导入统一异常处理器，简化命令方法的异常处理
 from .utils.exception_handlers import ExceptionHandler
 
-@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.7")
+@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "1.9.8")
 
 class MessageStatsPlugin(Star):
     """群发言统计插件
@@ -534,7 +534,7 @@ class MessageStatsPlugin(Star):
     
     # 排行榜数量限制常量（使用模块级常量）
     RANK_COUNT_MIN = 1
-    # MAX_RANK_COUNT 已从 constants 模块导入，不再重复定义
+    MAX_RANK_COUNT = 100  # 最大排行榜显示人数，来源: constants.MAX_RANK_COUNT
     
     # 图片模式别名常量
     IMAGE_MODE_ENABLE_ALIASES = {'1', 'true', '开', 'on', 'yes'}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display_name: AstrBot 群发言统计插件
 author: "xiaoruange39 & AMYdd00"
 description: "QQ群消息统计插件，支持消息数量统计和排行榜生成"
 short_description: "统计群成员发言次数，支持多种排行榜和定时推送"
-version: "1.9.7"
+version: "1.9.8"
 
 
 repo: "https://github.com/xiaoruange39/astrbot_plugin_message_stats"

--- a/utils/models.py
+++ b/utils/models.py
@@ -206,6 +206,8 @@ class UserData:
     llm_title: Optional[str] = None
     # LLM 生成的头衔颜色（持久化到文件），如 "#EF4444"
     llm_title_color: Optional[str] = None
+    # LLM 生成头衔时的用户发言数（持久化到文件），用于增量更新判断
+    llm_title_message_count: int = 0
     # display_title / display_title_color 为运行时属性，从 llm_title / llm_title_color 映射而来
     # 兼容旧代码逻辑，用于图片生成等场景
     display_title: Optional[str] = None
@@ -318,6 +320,9 @@ class UserData:
             result["llm_title"] = self.llm_title
         if self.llm_title_color:
             result["llm_title_color"] = self.llm_title_color
+        # 持久化头衔生成时的发言数（用于增量更新）
+        if self.llm_title_message_count > 0:
+            result["llm_title_message_count"] = self.llm_title_message_count
         return result
 
     
@@ -374,6 +379,9 @@ class UserData:
             user_data.llm_title = data["llm_title"]
         if "llm_title_color" in data:
             user_data.llm_title_color = data["llm_title_color"]
+        # 恢复头衔生成时的发言数（用于增量更新）
+        if "llm_title_message_count" in data:
+            user_data.llm_title_message_count = data["llm_title_message_count"]
         
         return user_data
 


### PR DESCRIPTION

### `llm_title_message_count` 未定义导致 LLM 头衔报错
Docker 日志显示：`AttributeError: 'UserData' object has no attribute 'llm_title_message_count'`
`UserData` 是 `@dataclass`，`llm_title_message_count` 未在类中声明，访问时直接崩溃。
→ 在 `models.py` 中添加字段声明，并在 `to_dict()`/`from_dict()` 中完成持久化