### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+## v2.1.1 (2026-06-05)
+
+### 🐛 Bug 修复
+- **修复 `_cleanup_stale_temp_files` 遗漏 Chromium 临时目录清理**：启动清理仅匹配 `playwright-*`/`playwright_*`/`msgstats_pw_*` 三种前缀，遗漏了 Chromium 原生 user data dir（`org.chromium.Chromium.*`）、artifacts（`playwright-artifacts-*`）、chromium dev profile（`playwright_chromiumdev_profile-*`）和 PulseAudio socket（`pulse-*`），导致容器 OOM/kill -9/断电等异常终止后这些空目录永久残留。
+
 ## v2.1.0 (2026-06-04)
 
 ### 🐛 Bug 修复

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ from .utils.constants import (
 # 导入统一异常处理器，简化命令方法的异常处理
 from .utils.exception_handlers import ExceptionHandler
 
-@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "2.1.0")
+@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "2.1.1")
 
 class MessageStatsPlugin(Star):
     """群发言统计插件

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display_name: AstrBot 群发言统计插件
 author: "xiaoruange39 & AMYdd00"
 description: "QQ群消息统计插件，支持消息数量统计和排行榜生成"
 short_description: "统计群成员发言次数，支持多种排行榜和定时推送"
-version: "2.1.0"
+version: "2.1.1"
 
 astrbot_version: ">=4.16,<5"
 

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -590,8 +590,17 @@ class ImageGenerator:
                 entry_path = os.path.join(temp_dir, entry)
                 if not os.path.isdir(entry_path):
                     continue
-                # Playwright 自动生成的临时目录前缀
-                if entry.startswith(("playwright-", "playwright_", "msgstats_pw_")):
+                # Playwright / Chromium 自动生成的临时目录前缀
+                # 包含 org.chromium.Chromium.*（Chromium 原生 user data dir）、
+                # playwright-artifacts-*、playwright_chromiumdev_profile-*、pulse-* 等
+                if entry.startswith((
+                    "playwright-", "playwright_",
+                    "msgstats_pw_",
+                    "org.chromium.Chromium.",
+                    "playwright-artifacts-",
+                    "playwright_chromiumdev_profile-",
+                    "pulse-",
+                )):
                     try:
                         shutil.rmtree(entry_path, ignore_errors=True)
                         pw_dirs_cleaned += 1


### PR DESCRIPTION
### 🐛 Bug 修复
- **修复 `_cleanup_stale_temp_files` 遗漏 Chromium 临时目录清理**：启动清理仅匹配 `playwright-*`/`playwright_*`/`msgstats_pw_*` 三种前缀，遗漏了 Chromium 原生 user data dir（`org.chromium.Chromium.*`）、artifacts（`playwright-artifacts-*`）、chromium dev profile（`playwright_chromiumdev_profile-*`）和 PulseAudio socket（`pulse-*`），导致容器 OOM/kill -9/断电等异常终止后这些空目录永久残留。