### PR TITLE
feat: v2.2.0 - 里程碑卡片新增表情包/贴图占比统计

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # 更新日志
 
+## v2.2.0 (2026-07-28)
+
+### ✨ 新功能
+- **里程碑卡片新增表情包统计**：发言里程碑卡片现在显示表情包/贴图/图片的数量及占总发言的百分比
+- **消息类型细分统计**：`UserData` 新增 `sticker_count` / `_sticker_dates` 字段，自动检测消息组件类型（Image/Face/Sticker）分类统计并持久化
+
+### 🔧 技术改进
+- 新增 `_is_sticker_message()` 方法，遍历消息链组件类型识别贴图/图片消息
+- `add_message()` 新增 `is_sticker` 参数，全程透传至数据持久层
+- `generate_milestone_image()` 接收 `sticker_count` / `sticker_percentage` 渲染到模板
+
 ## v2.1.9 (2026-07-11)
 
 ### ✨ 新功能

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ def _install_feature_methods(*feature_classes):
     return decorator
 
 
-@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "2.1.9")
+@register("astrbot_plugin_message_stats", "xiaoruange39", "群发言统计插件", "2.2.0")
 @_install_feature_methods(WebPanelMixin, StatsMixin, RankingMixin)
 class MessageStatsPlugin(Star):
     """群发言统计插件
@@ -597,10 +597,13 @@ class MessageStatsPlugin(Star):
         # 收集群组的unified_msg_origin（重要：用于定时推送）
         await self._collect_group_unified_msg_origin(event)
         
+        # 检测消息是否包含贴图/表情包/图片组件
+        is_sticker = self._is_sticker_message(event)
+        
         # 获取用户昵称并记录统计
         snapshot = extract_group_message_snapshot(event, user_id)
         await self._cache_group_name(event, group_id, snapshot.group_name)
-        await self._record_message_stats(group_id, user_id, snapshot.nickname, snapshot.group_name, snapshot.avatar_url)
+        await self._record_message_stats(group_id, user_id, snapshot.nickname, snapshot.group_name, snapshot.avatar_url, is_sticker=is_sticker)
     
     # ========== 排行榜命令 ==========
 
@@ -693,6 +696,12 @@ class MessageStatsPlugin(Star):
                 yield event.plain_result("图片生成器未初始化，无法生成个人里程碑卡片！")
                 return
 
+            # 计算表情包数量和占比
+            sticker_count = 0
+            if target_user_data:
+                sticker_count = target_user_data.sticker_count
+            sticker_percentage = round(sticker_count / current_count * 100, 1) if current_count > 0 else 0
+
             # 生成里程碑个人成就卡片
             image_path = await self.image_generator.generate_milestone_image(
                 user_id=user_id,
@@ -704,7 +713,9 @@ class MessageStatsPlugin(Star):
                 last_date=last_date,
                 group_total_messages=group_total_messages,
                 percentage=percentage,
-                group_info=group_info
+                group_info=group_info,
+                sticker_count=sticker_count,
+                sticker_percentage=sticker_percentage
             )
             
             if not image_path:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ display_name: AstrBot 群发言统计插件
 author: "xiaoruange39 & AMYdd00"
 description: "QQ群消息统计插件，支持消息数量统计和排行榜生成"
 short_description: "统计群成员发言次数，支持多种排行榜和定时推送"
-version: "2.1.9"
+version: "2.2.0"
 repo: "https://github.com/xiaoruange39/astrbot_plugin_message_stats"
 astrbot_version: ">=4.16"
 support_platforms:

--- a/templates/milestone_template.html
+++ b/templates/milestone_template.html
@@ -203,10 +203,13 @@
                     <div class="info-row">
                         群内排名 <span style="color: #ff2244;">#{{ rank }}</span>
                     </div>
-                    <div class="info-row">
-                        { 击败了群内 <span style="color: #ff2244;">{{ percentage }}%</span> 的活跃群友 }
-                    </div>
-                </div>
+                     <div class="info-row">
+                         { 击败了群内 <span style="color: #ff2244;">{{ percentage }}%</span> 的活跃群友 }
+                     </div>
+                     <div class="info-row">
+                         其中表情包 <span style="color: #ff2244;">{{ sticker_count }}</span> 条，占比 <span style="color: #ff2244;">{{ sticker_percentage }}%</span>
+                     </div>
+                 </div>
             </div>
         </div>
 

--- a/utils/data_manager.py
+++ b/utils/data_manager.py
@@ -371,7 +371,7 @@ class DataManager:
             self.logger.error(f"群组 {group_id} 数据保存失败")
     
     @safe_data_operation(default_return=(False, 0))
-    async def update_user_message(self, group_id: str, user_id: str, nickname: str, group_name: str = None, avatar_url: str = None) -> tuple:
+    async def update_user_message(self, group_id: str, user_id: str, nickname: str, group_name: str = None, avatar_url: str = None, is_sticker: bool = False) -> tuple:
         """更新用户消息统计
         
         异步更新指定用户在群组中的消息统计，包括新增用户和更新现有用户。
@@ -416,7 +416,7 @@ class DataManager:
                     user.avatar_url = avatar_url
                 today = datetime.now().date()
                 message_date = MessageDate.from_date(today)
-                user.add_message(message_date)
+                user.add_message(message_date, is_sticker=is_sticker)
                 user.last_message_time = current_timestamp
                 if user.first_message_time is None:
                     user.first_message_time = current_timestamp
@@ -435,7 +435,7 @@ class DataManager:
                     avatar_url=avatar_url
                 )
                 # 添加第一条消息记录（这会将message_count增加到1）
-                new_user.add_message(message_date)
+                new_user.add_message(message_date, is_sticker=is_sticker)
                 users_dict[user_id] = new_user
             
             # 将字典转换回列表

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -1038,7 +1038,9 @@ class ImageGenerator:
                                        last_date: str,
                                        group_total_messages: int,
                                        percentage: float,
-                                       group_info: GroupInfo) -> str:
+                                       group_info: GroupInfo,
+                                       sticker_count: int = 0,
+                                       sticker_percentage: float = 0.0) -> str:
         """生成里程碑个人成就卡片图片
         
         生成一张精美的个人成就卡片，替代里程碑触发时发送整个排行榜。
@@ -1102,6 +1104,8 @@ class ImageGenerator:
                 'last_date': self._escape_html_safe(last_date or "未知"),
                 'group_total_messages': group_total_messages,
                 'percentage': f"{percentage:.2f}",
+                'sticker_count': sticker_count,
+                'sticker_percentage': f"{sticker_percentage:.1f}",
                 'current_time': current_time,
                 'custom_font_css': self._get_custom_font_css(),
             }

--- a/utils/models.py
+++ b/utils/models.py
@@ -266,6 +266,7 @@ class UserData:
     user_id: str
     nickname: str
     message_count: int = 0
+    sticker_count: int = 0
     history: List[MessageDate] = field(default_factory=list)
     last_date: Optional[str] = None
     first_message_time: Optional[int] = None
@@ -274,6 +275,8 @@ class UserData:
     # 按天聚合的字典 {date_str: count}，替代 history 列表存储
     # 10万条消息最多365个键值对，内存占用从O(n)降到O(365)
     _message_dates: Dict[str, int] = field(default_factory=dict)
+    # 按天聚合的贴图计数 {date_str: count}
+    _sticker_dates: Dict[str, int] = field(default_factory=dict)
     # LLM 生成的头衔文本（持久化到文件，重启后依然保留）
     llm_title: Optional[str] = None
     # LLM 生成的头衔颜色（持久化到文件），如 "#EF4444"
@@ -290,7 +293,7 @@ class UserData:
 
 
     
-    def add_message(self, message_date: MessageDate):
+    def add_message(self, message_date: MessageDate, is_sticker: bool = False):
         """添加消息记录
         
         增加用户的发言计数并记录发言日期。使用按天聚合的字典存储，
@@ -298,6 +301,7 @@ class UserData:
         
         Args:
             message_date (MessageDate): 消息日期对象
+            is_sticker (bool): 是否为表情包/贴图消息，默认 False
             
         Returns:
             None: 无返回值，直接修改对象状态
@@ -310,6 +314,13 @@ class UserData:
         if date_str not in self._message_dates:
             self._message_dates[date_str] = 0
         self._message_dates[date_str] += 1
+        
+        # 如果是贴图消息，更新贴图计数
+        if is_sticker:
+            self.sticker_count += 1
+            if date_str not in self._sticker_dates:
+                self._sticker_dates[date_str] = 0
+            self._sticker_dates[date_str] += 1
         
         # 更新最后发言日期
         self.last_date = date_str
@@ -389,6 +400,11 @@ class UserData:
         }
         if self.avatar_url:
             result["avatar_url"] = self.avatar_url
+        # 持久化贴图计数
+        if self.sticker_count > 0:
+            result["sticker_count"] = self.sticker_count
+        if self._sticker_dates:
+            result["sticker_dates"] = {k: v for k, v in sorted(self._sticker_dates.items())}
         # 持久化头衔字段
         if self.llm_title:
             result["llm_title"] = self.llm_title
@@ -449,6 +465,11 @@ class UserData:
             except TypeError as e:
                 logger.warning(f"history字段类型错误: {type(data.get('history'))}, 错误: {e}")
         
+        # 恢复持久化的贴图计数
+        if "sticker_count" in data:
+            user_data.sticker_count = data["sticker_count"]
+        if "sticker_dates" in data and isinstance(data["sticker_dates"], dict):
+            user_data._sticker_dates = {k: int(v) for k, v in data["sticker_dates"].items()}
         # 恢复持久化的头衔字段
         if "llm_title" in data:
             user_data.llm_title = data["llm_title"]

--- a/utils/stats_mixin.py
+++ b/utils/stats_mixin.py
@@ -1,5 +1,6 @@
 """消息记录、群信息缓存、昵称解析和里程碑能力。"""
 
+import re
 from typing import Any, Dict, List, Optional, Set
 
 import orjson
@@ -246,8 +247,37 @@ class StatsMixin:
             return self_id and user_id == str(self_id)
         except (AttributeError, KeyError, TypeError):
             return False
-
-    async def _record_message_stats(self, group_id: str, user_id: str, nickname: str, group_name: Optional[str] = None, avatar_url: Optional[str] = None):
+    
+    def _is_sticker_message(self, event: AstrMessageEvent) -> bool:
+        """检测消息是否包含 QQ 表情/贴图（Face/Mface）
+        
+        从原始消息字符串（message_obj.message_str）中匹配 CQ 码。
+        注意：普通 Image（图片）[CQ:image 不计入贴图统计。
+        
+        Args:
+            event: 消息事件对象
+            
+        Returns:
+            bool: 是否包含 Face/Mface 组件
+        """
+        try:
+            # 优先使用 message_obj.message_str（原始 CQ 码字符串）
+            message_obj = getattr(event, 'message_obj', None)
+            if message_obj:
+                raw = str(getattr(message_obj, 'message_str', '') or '').strip()
+            else:
+                raw = ""
+            if not raw:
+                return False
+            # 匹配 [CQ:face,...] 和 [CQ:mface,...]（大小写不敏感）
+            has_sticker = bool(re.search(r'\[CQ:(?:face|mface)', raw, re.IGNORECASE))
+            if has_sticker and self.plugin_config.detailed_logging_enabled:
+                self.logger.debug(f"_is_sticker_message: 匹配到 face/mface CQ 码")
+            return has_sticker
+        except Exception:
+            return False
+    
+    async def _record_message_stats(self, group_id: str, user_id: str, nickname: str, group_name: Optional[str] = None, avatar_url: Optional[str] = None, is_sticker: bool = False):
         """记录消息统计
 
         内部方法,用于记录群成员的消息统计数据.会自动验证输入参数并更新数据.
@@ -286,7 +316,7 @@ class StatsMixin:
             group_id, user_id, nickname = validated_data
 
             # 步骤3: 处理消息统计和记录
-            await self._process_message_stats(group_id, user_id, nickname, group_name, avatar_url)
+            await self._process_message_stats(group_id, user_id, nickname, group_name, avatar_url, is_sticker)
 
         except Exception as e:
             self.logger.error(f"记录消息统计失败({type(e).__name__}): {e}", exc_info=True)
@@ -316,7 +346,7 @@ class StatsMixin:
 
         return group_id, user_id, nickname
 
-    async def _process_message_stats(self, group_id: str, user_id: str, nickname: str, group_name: Optional[str] = None, avatar_url: Optional[str] = None):
+    async def _process_message_stats(self, group_id: str, user_id: str, nickname: str, group_name: Optional[str] = None, avatar_url: Optional[str] = None, is_sticker: bool = False):
         """处理消息统计和记录
 
         执行实际的消息统计更新操作，并记录结果日志。
@@ -327,14 +357,18 @@ class StatsMixin:
             group_id (str): 验证后的群组ID
             user_id (str): 验证后的用户ID
             nickname (str): 验证后的用户昵称
+            is_sticker (bool): 是否为表情包/贴图消息
         """
         # 直接使用data_manager更新用户消息，同时获取更新后的总发言数
+        if self.plugin_config.detailed_logging_enabled:
+            self.logger.debug(f"_process_message_stats: user={nickname}, is_sticker={is_sticker}")
         success, message_count = await self.data_manager.update_user_message(
             group_id,
             user_id,
             nickname,
             group_name=group_name,
             avatar_url=avatar_url,
+            is_sticker=is_sticker,
         )
 
         if success:
@@ -443,6 +477,12 @@ class StatsMixin:
                 self.logger.warning("里程碑推送：图片生成器未初始化")
                 return
 
+            # 计算表情包数量和占比
+            sticker_count = 0
+            if target_user_data:
+                sticker_count = target_user_data.sticker_count
+            sticker_percentage = round(sticker_count / current_count * 100, 1) if current_count > 0 else 0
+
             # 生成里程碑个人成就卡片
             image_path = await self.image_generator.generate_milestone_image(
                 user_id=user_id,
@@ -454,7 +494,9 @@ class StatsMixin:
                 last_date=last_date,
                 group_total_messages=group_total_messages,
                 percentage=percentage,
-                group_info=group_info
+                group_info=group_info,
+                sticker_count=sticker_count,
+                sticker_percentage=sticker_percentage
             )
 
             if not image_path:


### PR DESCRIPTION
- UserData 新增 sticker_count 和 _sticker_dates 字段，支持表情包计数持久化
- _is_sticker_message: 解析原始 CQ 码匹配 [CQ:face]/[CQ:mface]，排除普通 Image
- 整条链路透传 is_sticker 参数：main.py → stats_mixin → data_manager → UserData.add_message
- 里程碑卡片模板新增「其中表情包 X 条，占比 X%」展示
- show_my_milestone 命令同样支持展示贴图统计
- 版本号更新至 2.2.0