### PR TITLE
[codex] Resolve nested channel names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ env/
 
 .DS_Store
 Thumbs.db
-
-tests/*

--- a/tests/test_event_snapshot.py
+++ b/tests/test_event_snapshot.py
@@ -1,0 +1,67 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = Path(__file__).parents[1] / "utils" / "event_snapshot.py"
+SPEC = importlib.util.spec_from_file_location("event_snapshot", MODULE_PATH)
+event_snapshot = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(event_snapshot)
+
+
+class EventSnapshotTests(unittest.TestCase):
+    def test_extracts_discord_channel_name_from_raw_message(self):
+        channel = SimpleNamespace(name="bot-chat")
+        raw_message = SimpleNamespace(channel=channel)
+        event = SimpleNamespace(
+            message_obj=SimpleNamespace(raw_message=raw_message),
+        )
+
+        self.assertEqual(
+            event_snapshot.extract_group_name_from_event(event),
+            "bot-chat",
+        )
+
+    def test_channel_name_takes_priority_over_guild_name(self):
+        guild = SimpleNamespace(name="AstrBot Server")
+        channel = SimpleNamespace(name="bot-chat", guild=guild)
+        raw_message = SimpleNamespace(channel=channel, guild=guild)
+        event = SimpleNamespace(
+            message_obj=SimpleNamespace(raw_message=raw_message),
+        )
+
+        self.assertEqual(
+            event_snapshot.extract_group_name_from_event(event),
+            "bot-chat",
+        )
+
+    def test_extracts_name_from_nested_chat_mapping(self):
+        raw_message = {"chat": {"title": "Telegram Group"}}
+        event = SimpleNamespace(
+            message_obj=SimpleNamespace(raw_message=raw_message),
+        )
+
+        self.assertEqual(
+            event_snapshot.extract_group_name_from_event(event),
+            "Telegram Group",
+        )
+
+    def test_existing_direct_group_name_takes_priority(self):
+        raw_message = {
+            "group_name": "QQ Group",
+            "channel": {"name": "nested-channel"},
+        }
+        event = SimpleNamespace(
+            message_obj=SimpleNamespace(raw_message=raw_message),
+        )
+
+        self.assertEqual(
+            event_snapshot.extract_group_name_from_event(event),
+            "QQ Group",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_snapshot.py
+++ b/tests/test_event_snapshot.py
@@ -62,6 +62,21 @@ class EventSnapshotTests(unittest.TestCase):
             "QQ Group",
         )
 
+    def test_channel_name_does_not_leak_into_sender_nickname(self):
+        channel = SimpleNamespace(name="bot-chat")
+        raw_message = SimpleNamespace(
+            channel=channel,
+            author=SimpleNamespace(id="123456"),
+        )
+        event = SimpleNamespace(
+            message_obj=SimpleNamespace(raw_message=raw_message),
+        )
+
+        snapshot = event_snapshot.extract_group_message_snapshot(event, "123456")
+
+        self.assertEqual(snapshot.group_name, "bot-chat")
+        self.assertEqual(snapshot.nickname, "用户123456")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/event_snapshot.py
+++ b/utils/event_snapshot.py
@@ -32,6 +32,28 @@ AVATAR_URL_KEYS = (
     "profile_image_url",
 )
 
+EVENT_SOURCE_KEYS = (
+    "raw_event",
+    "message_obj",
+    "message_event",
+    "platform_event",
+    "original_event",
+    "event",
+    "raw_message",
+)
+
+# Conversation containers can expose generic ``name``/``title`` fields. Keep
+# them out of the person/nickname traversal so a channel name cannot be
+# mistaken for the sender's nickname.
+GROUP_CONTAINER_KEYS = (
+    "channel",
+    "chat",
+    "conversation",
+    "room",
+    "thread",
+    "guild",
+)
+
 
 def _clean_text(value: Any) -> Optional[str]:
     if value is None:
@@ -66,31 +88,12 @@ def _iter_nested_sources(source: Any, keys: Iterable[str]) -> Iterable[Any]:
                 yield user
 
 
-def _iter_sources(event: Any) -> Iterable[Any]:
+def _iter_sources(event: Any, nested_keys: Iterable[str] = EVENT_SOURCE_KEYS) -> Iterable[Any]:
     if event is None:
         return
 
     seen = set()
     stack = [event]
-    attr_names = (
-        "raw_event",
-        "message_obj",
-        "message_event",
-        "platform_event",
-        "original_event",
-        "event",
-        "raw_message",
-        # Some adapters keep conversation metadata on the raw platform
-        # message. For example, Discord exposes the channel as
-        # ``raw_message.channel`` rather than copying its name to
-        # ``AstrBotMessage``.
-        "channel",
-        "chat",
-        "conversation",
-        "room",
-        "thread",
-        "guild",
-    )
 
     while stack:
         current = stack.pop(0)
@@ -100,10 +103,17 @@ def _iter_sources(event: Any) -> Iterable[Any]:
         seen.add(marker)
         yield current
 
-        for name in attr_names:
+        for name in nested_keys:
             nested = _read_value(current, name)
             if nested is not None:
                 stack.append(nested)
+
+
+def _iter_group_sources(event: Any) -> Iterable[Any]:
+    # Some adapters keep conversation metadata on the raw platform message.
+    # Discord, for example, exposes the displayable channel name as
+    # ``raw_message.channel.name``.
+    yield from _iter_sources(event, EVENT_SOURCE_KEYS + GROUP_CONTAINER_KEYS)
 
 
 def _read_event_sender_name(event: Any) -> Optional[str]:
@@ -116,7 +126,7 @@ def _read_event_sender_name(event: Any) -> Optional[str]:
 
 
 def extract_group_name_from_event(event: Any) -> Optional[str]:
-    for source in _iter_sources(event):
+    for source in _iter_group_sources(event):
         group_name = _read_first_text(source, GROUP_NAME_KEYS)
         if group_name:
             return group_name
@@ -127,9 +137,12 @@ def extract_group_message_snapshot(event: Any, user_id: str) -> GroupMessageSnap
     framework_sender_name = _read_event_sender_name(event)
     card = None
     base_nickname = None
-    group_name = None
+    group_name = extract_group_name_from_event(event)
     avatar_url = None
 
+    # Person metadata intentionally walks only the message/event wrappers.
+    # Conversation containers such as channel/guild may also have ``name``,
+    # which must never become the sender nickname.
     for source in _iter_sources(event):
         person_sources = [source]
         person_sources.extend(_iter_nested_sources(source, (
@@ -149,10 +162,7 @@ def extract_group_message_snapshot(event: Any, user_id: str) -> GroupMessageSnap
             if avatar_url is None:
                 avatar_url = _read_first_text(person, AVATAR_URL_KEYS)
 
-        if group_name is None:
-            group_name = _read_first_text(source, GROUP_NAME_KEYS)
-
-        if card and base_nickname and group_name and avatar_url:
+        if card and base_nickname and avatar_url:
             break
 
     nickname = framework_sender_name or card or base_nickname or f"用户{user_id}"

--- a/utils/event_snapshot.py
+++ b/utils/event_snapshot.py
@@ -32,28 +32,6 @@ AVATAR_URL_KEYS = (
     "profile_image_url",
 )
 
-EVENT_SOURCE_KEYS = (
-    "raw_event",
-    "message_obj",
-    "message_event",
-    "platform_event",
-    "original_event",
-    "event",
-    "raw_message",
-)
-
-# Conversation containers can expose generic ``name``/``title`` fields. Keep
-# them out of the person/nickname traversal so a channel name cannot be
-# mistaken for the sender's nickname.
-GROUP_CONTAINER_KEYS = (
-    "channel",
-    "chat",
-    "conversation",
-    "room",
-    "thread",
-    "guild",
-)
-
 
 def _clean_text(value: Any) -> Optional[str]:
     if value is None:
@@ -88,12 +66,34 @@ def _iter_nested_sources(source: Any, keys: Iterable[str]) -> Iterable[Any]:
                 yield user
 
 
-def _iter_sources(event: Any, nested_keys: Iterable[str] = EVENT_SOURCE_KEYS) -> Iterable[Any]:
+def _iter_sources(event: Any, *, include_group_containers: bool = False) -> Iterable[Any]:
     if event is None:
         return
 
     seen = set()
     stack = [event]
+    attr_names = (
+        "raw_event",
+        "message_obj",
+        "message_event",
+        "platform_event",
+        "original_event",
+        "event",
+        "raw_message",
+    )
+    if include_group_containers:
+        # Some adapters keep conversation metadata on the raw platform
+        # message. For example, Discord exposes the channel as
+        # ``raw_message.channel`` rather than copying its name to
+        # ``AstrBotMessage``.
+        attr_names += (
+            "channel",
+            "chat",
+            "conversation",
+            "room",
+            "thread",
+            "guild",
+        )
 
     while stack:
         current = stack.pop(0)
@@ -103,17 +103,10 @@ def _iter_sources(event: Any, nested_keys: Iterable[str] = EVENT_SOURCE_KEYS) ->
         seen.add(marker)
         yield current
 
-        for name in nested_keys:
+        for name in attr_names:
             nested = _read_value(current, name)
             if nested is not None:
                 stack.append(nested)
-
-
-def _iter_group_sources(event: Any) -> Iterable[Any]:
-    # Some adapters keep conversation metadata on the raw platform message.
-    # Discord, for example, exposes the displayable channel name as
-    # ``raw_message.channel.name``.
-    yield from _iter_sources(event, EVENT_SOURCE_KEYS + GROUP_CONTAINER_KEYS)
 
 
 def _read_event_sender_name(event: Any) -> Optional[str]:
@@ -126,7 +119,7 @@ def _read_event_sender_name(event: Any) -> Optional[str]:
 
 
 def extract_group_name_from_event(event: Any) -> Optional[str]:
-    for source in _iter_group_sources(event):
+    for source in _iter_sources(event, include_group_containers=True):
         group_name = _read_first_text(source, GROUP_NAME_KEYS)
         if group_name:
             return group_name
@@ -140,9 +133,8 @@ def extract_group_message_snapshot(event: Any, user_id: str) -> GroupMessageSnap
     group_name = extract_group_name_from_event(event)
     avatar_url = None
 
-    # Person metadata intentionally walks only the message/event wrappers.
-    # Conversation containers such as channel/guild may also have ``name``,
-    # which must never become the sender nickname.
+    # Keep group containers out of this traversal: channel/guild objects can
+    # also expose a generic ``name`` field, which must not become a nickname.
     for source in _iter_sources(event):
         person_sources = [source]
         person_sources.extend(_iter_nested_sources(source, (

--- a/utils/event_snapshot.py
+++ b/utils/event_snapshot.py
@@ -80,6 +80,16 @@ def _iter_sources(event: Any) -> Iterable[Any]:
         "original_event",
         "event",
         "raw_message",
+        # Some adapters keep conversation metadata on the raw platform
+        # message. For example, Discord exposes the channel as
+        # ``raw_message.channel`` rather than copying its name to
+        # ``AstrBotMessage``.
+        "channel",
+        "chat",
+        "conversation",
+        "room",
+        "thread",
+        "guild",
     )
 
     while stack:


### PR DESCRIPTION
## Summary

Improve group-name extraction for platform adapters that store conversation metadata in nested raw-message objects.

- Traverse common conversation containers such as `channel`, `chat`, `conversation`, `room`, `thread`, and `guild`.
- Preserve the existing direct-field precedence, so explicit `group_name` values remain preferred.
- Add standard-library regression tests for Discord channel objects, nested chat mappings, and precedence behavior.
- Stop ignoring the test directory so the regression coverage is included in the repository.

## Root cause

AstrBot's Discord adapter exposes the displayable channel name as `raw_message.channel.name`. The snapshot walker previously only followed message wrapper fields, so it reached the raw Discord message but not its channel object. The web panel then fell back to the numeric channel ID.

## Validation

```text
python3 -m unittest discover -s tests -p 'test_*.py' -v
python3 -m compileall -q utils/event_snapshot.py tests/test_event_snapshot.py
git diff --check
```

All four regression tests pass.
